### PR TITLE
Improvements to build and task log stability

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -248,9 +248,10 @@ services:
   local-minio:
     image: minio/minio
     entrypoint: sh
-    command: -c 'mkdir -p /export/lagoon-files && mkdir -p /export/harbor-images && /usr/bin/minio server /export'
+    command: -c 'mkdir -p /export/lagoon-files && mkdir -p /export/harbor-images && minio server /export --console-address ":9001" '
     ports:
       - '9000:9000'
+      - '9001:9001'
     environment:
       - MINIO_ACCESS_KEY=minio
       - MINIO_SECRET_KEY=minio123

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -51,6 +51,12 @@ services:
     volumes:
       - ./services/logs2webhook/src:/app/services/logs2webhook/src
       - ./node-packages:/app/node-packages:delegated
+  logs2s3:
+    image: ${IMAGE_REPO:-lagoon}/logs2s3
+    command: yarn run dev
+    volumes:
+      - ./services/logs2s3/src:/app/services/logs2s3/src
+      - ./node-packages:/app/node-packages:delegated
   logs2microsoftteams:
     image: ${IMAGE_REPO:-lagoon}/logs2microsoftteams
     command: yarn run dev

--- a/images/yarn-workspace-builder/Dockerfile
+++ b/images/yarn-workspace-builder/Dockerfile
@@ -17,6 +17,7 @@ COPY services/logs2email/package.json /app/services/logs2email/
 COPY services/logs2microsoftteams/package.json /app/services/logs2microsoftteams/
 COPY services/logs2rocketchat/package.json /app/services/logs2rocketchat/
 COPY services/logs2slack/package.json /app/services/logs2slack/
+COPY services/logs2s3/package.json /app/services/logs2s3/
 COPY services/logs2webhook/package.json /app/services/logs2webhook/
 COPY services/controllerhandler/package.json /app/services/controllerhandler/
 COPY services/webhook-handler/package.json /app/services/webhook-handler/

--- a/services/api/src/resources/task/resolvers.ts
+++ b/services/api/src/resources/task/resolvers.ts
@@ -4,13 +4,39 @@ import {
   pubSub,
   createEnvironmentFilteredSubscriber
 } from '../../clients/pubSub';
-import { esClient } from '../../clients/esClient';
 import { knex, query, isPatchEmpty } from '../../util/db';
 import { Sql } from './sql';
 import { EVENTS } from './events';
 import { Helpers } from './helpers';
 import { Helpers as environmentHelpers } from '../environment/helpers';
 import { Validators as envValidators } from '../environment/validators';
+import S3 from 'aws-sdk/clients/s3';
+
+const accessKeyId =  process.env.S3_FILES_ACCESS_KEY_ID || 'minio'
+const secretAccessKey =  process.env.S3_FILES_SECRET_ACCESS_KEY || 'minio123'
+const bucket = process.env.S3_FILES_BUCKET || 'lagoon-files'
+const region = process.env.S3_FILES_REGION
+const s3Origin = process.env.S3_FILES_HOST || 'http://docker.for.mac.localhost:9000'
+
+const config = {
+  origin: s3Origin,
+  accessKeyId: accessKeyId,
+  secretAccessKey: secretAccessKey,
+  region: region,
+  bucket: bucket
+};
+
+const s3Client = new S3({
+  endpoint: config.origin,
+  accessKeyId: config.accessKeyId,
+  secretAccessKey: config.secretAccessKey,
+  region: config.region,
+  params: {
+    Bucket: config.bucket
+  },
+  s3ForcePathStyle: true,
+  signatureVersion: 'v4'
+});
 
 export const getTaskLog: ResolverFn = async (
   { remoteId, status },
@@ -22,26 +48,13 @@ export const getTaskLog: ResolverFn = async (
   }
 
   try {
-    const result = await esClient.search({
-      index: 'lagoon-logs-*',
-      sort: '@timestamp:desc',
-      body: {
-        query: {
-          bool: {
-            must: [
-              { match_phrase: { 'meta.remoteId': remoteId } },
-              { match_phrase: { 'meta.jobStatus': status } }
-            ]
-          }
-        }
-      }
-    });
+    const data = await s3Client.getObject({Bucket: bucket, Key: 'tasklogs/'+remoteId+'.txt'}).promise();
 
-    if (!result.hits.total) {
+    if (!data) {
       return null;
     }
-
-    return R.path(['hits', 'hits', 0, '_source', 'message'], result);
+    let logMsg = new Buffer(JSON.parse(JSON.stringify(data.Body)).data).toString('ascii');
+    return logMsg;
   } catch (e) {
     return `There was an error loading the logs: ${e.message}`;
   }

--- a/services/logs2s3/.gitignore
+++ b/services/logs2s3/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/services/logs2s3/Dockerfile
+++ b/services/logs2s3/Dockerfile
@@ -1,0 +1,34 @@
+ARG LAGOON_GIT_BRANCH
+ARG IMAGE_REPO
+ARG UPSTREAM_REPO
+ARG UPSTREAM_TAG
+# STAGE 1: Loading Image lagoon-node-packages-builder which contains node packages shared by all Node Services
+FROM ${IMAGE_REPO:-lagoon}/yarn-workspace-builder as yarn-workspace-builder
+
+# STAGE 2: specific service Image
+FROM ${UPSTREAM_REPO:-uselagoon}/node-16:${UPSTREAM_TAG:-latest}
+
+ARG LAGOON_VERSION
+ENV LAGOON_VERSION=$LAGOON_VERSION
+
+# Copying generated node_modules from the first stage
+COPY --from=yarn-workspace-builder /app /app
+
+# Setting the workdir to the service, all following commands will run from here
+WORKDIR /app/services/logs2s3/
+
+# Copying the .env.defaults into the Workdir, as the dotenv system searches within the workdir for it
+COPY --from=yarn-workspace-builder /app/.env.defaults .
+
+# Copying files from our service
+COPY . .
+
+# Verify that all dependencies have been installed via the yarn-workspace-builder
+RUN yarn check --verify-tree
+
+# Making sure we run in production
+ENV NODE_ENV production
+
+RUN yarn build
+
+CMD ["yarn", "start"]

--- a/services/logs2s3/README.md
+++ b/services/logs2s3/README.md
@@ -1,0 +1,31 @@
+<p align="center"><img
+src="https://raw.githubusercontent.com/amazeeio/lagoon/master/docs/images/lagoon-logo.png"
+alt="The Lagoon logo is a blue hexagon split in two pieces with an L-shaped cut"
+width="40%"></p>
+
+This service is part of amazee.io Lagoon, a Docker build and deploy system for
+OpenShift & Kubernetes. Please reference our [documentation] for detailed
+information on using, developing, and administering Lagoon.
+
+# Logs to S3 (`logs2s3`)
+
+Watches all the Lagoon logs and checks for events that should trigger a push to S3. Each log message is tied to a Lagoon project, environment or task.
+
+This is a requirement for Build and Task logs within Lagoon.
+
+## Technology
+
+* Node.js
+* Message Queue
+
+## Related Services
+
+* API [***dependency***]
+* RabbitMQ [***dependency***]
+
+## Message Queues
+
+* Consumes: `lagoon-logs`, `lagoon-logs:s3`
+* Produces: `lagoon-logs:s3`
+
+[documentation]: https://docs.lagoon.sh/

--- a/services/logs2s3/package.json
+++ b/services/logs2s3/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "logs2s3",
+  "version": "0.0.1",
+  "description": "lagoon handler for s3 storage",
+  "author": "amazee.io <hello@amazee.io> (http://www.amazee.io)",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc --build",
+    "start": "node dist/index",
+    "dev": "mkdir -p ../../node-packages/commons/dist && NODE_ENV=development nodemon"
+  },
+  "nodemonConfig": {
+    "ignore": [
+      "../../node-packages/commons/dist/"
+    ],
+    "watch": [
+      "src",
+      "../../node-packages/"
+    ],
+    "ext": "js,ts,json",
+    "exec": "yarn build --incremental && yarn start --inspect=0.0.0.0:9229"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@lagoon/commons": "4.0.0",
+    "@slack/client": "^4.12.0",
+    "aws-sdk": "^2.378.0",
+    "amqp-connection-manager": "^1.3.5"
+  },
+  "devDependencies": {
+    "@types/amqp-connection-manager": "^2.0.10",
+    "nodemon": "^1.12.1",
+    "typescript": "^3.9.3"
+  }
+}

--- a/services/logs2s3/src/index.ts
+++ b/services/logs2s3/src/index.ts
@@ -1,0 +1,26 @@
+import amqp, { ChannelWrapper } from 'amqp-connection-manager';
+import { logger } from '@lagoon/commons/dist/local-logging';
+import { readFromRabbitMQ } from './readFromRabbitMQ';
+
+const rabbitmqHost = process.env.RABBITMQ_HOST || "broker"
+const rabbitmqUsername = process.env.RABBITMQ_USERNAME || "guest"
+const rabbitmqPassword = process.env.RABBITMQ_PASSWORD || "guest"
+// @ts-ignore
+const connection = amqp.connect([`amqp://${rabbitmqUsername}:${rabbitmqPassword}@${rabbitmqHost}`], { json: true });
+
+connection.on('connect', ({ url }) => logger.verbose('Connected to %s', url, { action: 'connected', url }));
+// @ts-ignore
+connection.on('disconnect', params => logger.error('Not connected, error: %s', params.err.code, { action: 'disconnected', reason: params }));
+
+// Cast any to ChannelWrapper to get type-safetiness through our own code
+const channelWrapperLogs: ChannelWrapper = connection.createChannel({
+	setup: channel => {
+		return Promise.all([
+			channel.assertExchange('lagoon-logs', 'direct', {durable: true}),
+			channel.assertQueue('lagoon-logs:s3', {durable: true}),
+			channel.bindQueue('lagoon-logs:s3', 'lagoon-logs', ''),
+			channel.prefetch(1),
+			channel.consume('lagoon-logs:s3', msg => readFromRabbitMQ(msg, channelWrapperLogs), {noAck: false}),
+		]);
+	}
+});

--- a/services/logs2s3/src/readFromRabbitMQ.ts
+++ b/services/logs2s3/src/readFromRabbitMQ.ts
@@ -1,0 +1,72 @@
+import { ChannelWrapper } from 'amqp-connection-manager';
+import { ConsumeMessage } from 'amqplib';
+import { logger } from '@lagoon/commons/dist/local-logging';
+import S3 from 'aws-sdk/clients/s3';
+
+const accessKeyId =  process.env.S3_FILES_ACCESS_KEY_ID || 'minio'
+const secretAccessKey =  process.env.S3_FILES_SECRET_ACCESS_KEY || 'minio123'
+const bucket = process.env.S3_FILES_BUCKET || 'lagoon-files'
+const region = process.env.S3_FILES_REGION
+const s3Origin = process.env.S3_FILES_HOST || 'http://docker.for.mac.localhost:9000'
+
+const config = {
+  origin: s3Origin,
+  accessKeyId: accessKeyId,
+  secretAccessKey: secretAccessKey,
+  region: region,
+  bucket: bucket
+};
+
+const s3Client = new S3({
+  endpoint: config.origin,
+  accessKeyId: config.accessKeyId,
+  secretAccessKey: config.secretAccessKey,
+  region: config.region,
+  params: {
+    Bucket: config.bucket
+  },
+  s3ForcePathStyle: true,
+  signatureVersion: 'v4'
+});
+
+export async function readFromRabbitMQ(
+  msg: ConsumeMessage,
+  channelWrapperLogs: ChannelWrapper
+): Promise<void> {
+  const logMessage = JSON.parse(msg.content.toString());
+
+  const { severity, project, uuid, event, meta, message } = logMessage;
+
+
+  switch (event) {
+    // handle builddeploy build logs from lagoon builds
+    case String(event.match(/^build-logs:builddeploy-kubernetes:.*/)):
+      logger.verbose(`received ${event} for project ${project} - ${meta.remoteId}`);
+      await s3Client.putObject({
+        Bucket: bucket,
+        Key: 'buildlogs/'+meta.remoteId+'.txt',
+        ContentType: 'text/plain',
+        Body: Buffer.from(message, 'binary')
+      }).promise();
+
+      channelWrapperLogs.ack(msg);
+      break;
+    // handle tasks events for tasks logs
+    // yes this says build-logs but it should be task-logs, will be fixed in controller and phased out at some stage
+    // the build-logs is a flow on from days past
+    case String(event.match(/^build-logs:job-kubernetes:.*/)):
+    case String(event.match(/^task-logs:job-kubernetes:.*/)):
+      logger.verbose(`received ${event} for project ${project} - ${meta.remoteId}`);
+      await s3Client.putObject({
+        Bucket: bucket,
+        Key: 'tasklogs/'+meta.remoteId+'.txt',
+        ContentType: 'text/plain',
+        Body: Buffer.from(message, 'binary')
+      }).promise();
+
+      channelWrapperLogs.ack(msg);
+      break;
+    default:
+      return channelWrapperLogs.ack(msg);
+  }
+}

--- a/services/logs2s3/tsconfig.json
+++ b/services/logs2s3/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["./src"],
+  "references": [
+    { "path": "../../node-packages/commons" }
+  ]
+}


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

This is the first phase in providing better stability for build logs in Lagoon. This moves the logs from being retrieved from Elasticsearch, to being retrieved from S3. 

A new service `logs2s3` is added which only handles uploading build and task logs into S3, nothing else. It is designed to handle any messages of the following type of events

* `build-logs:builddeploy-kubernetes:*` for build logs
* `build-logs:job-kubernetes:*` and `task-logs:job-kubernetes:*` for task logs

<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues

closes #2835 
