### PR TITLE
reference environment.id correctly in createTaskTask taskData

### DIFF
--- a/node-packages/commons/src/tasks.ts
+++ b/node-packages/commons/src/tasks.ts
@@ -859,7 +859,7 @@ export const createTaskTask = async function(taskData: any) {
     case 'lagoon_controllerJob':
       // since controllers queues are named, we have to send it to the right tasks queue
       // do that here by querying which deploytarget the environment uses
-      const result = await getOpenShiftInfoForEnvironment(taskData.data.environment.id);
+      const result = await getOpenShiftInfoForEnvironment(taskData.environment.id);
       const deployTarget = result.environment.openshift.name
       return sendToLagoonTasks(deployTarget+":jobs", taskData);
 


### PR DESCRIPTION
in #2829 a regression entered that caused the addTask resolver to not successfully trigger a task

```
[2021-10-15 23:16:05] [[31merror[39m]: lagoon-logs: Send to lagoon-logs: *[ci-tasks-control-k8s]* Task not initiated, reason: TypeError: Cannot read property 'environment' of undefined
```

This PR correctly sets the environment.id for the `getOpenShiftInfoForEnvironment` in createTaskTask