### PR TITLE
Clean up any deploytarget configurations when removing projects

### DIFF
--- a/services/api/src/resources/project/resolvers.ts
+++ b/services/api/src/resources/project/resolvers.ts
@@ -533,6 +533,15 @@ export const deleteProject: ResolverFn = async (
     );
   }
 
+  // clean up deploytarget configurations for this project
+  try {
+    await query(sqlClientPool, 'DELETE FROM deploy_target_config WHERE project = :pid', {
+      pid
+    });
+  } catch (err) {
+     // Not allowed to stop execution.
+  }
+
   // @TODO discuss if we want to delete projects in harbor or not
   //const harborOperations = createHarborOperations(sqlClientPool);
 


### PR DESCRIPTION
This PR implements logic to ensure that any deployTargets are cleared up when a project is removed.  Less likely to be an issue in production, but in testing or local this resulted in projects incorrectly assuming that they had deploytargets configured.