### PR TITLE
Fix retry loop logic in testing

### DIFF
--- a/tests/tasks/api/deploy-no-sha.yaml
+++ b/tests/tasks/api/deploy-no-sha.yaml
@@ -1,6 +1,9 @@
-- name: "{{ testname }} - POST api deployEnvironmentBranch with target git branch {{ branch }} and project {{ project }} (no sha) to {{ graphql_url }}"
+- name: "Start deployEnvironmentBranch (no SHA) loop with 3 retries"
   block:
     - include: refresh-token.yaml
+    - name: "Set the retry count to {{ retry_count }}"
+      set_fact:
+        retry_count: "{{ 0 if retry_count is undefined else retry_count|int + 1 }}"
     - name: "{{ testname }} - POST api deployEnvironmentBranch with target git branch {{ branch }} and project {{ project }} (no sha) to {{ graphql_url }}"
       uri:
         url: "{{ graphql_url }}"
@@ -8,13 +11,27 @@
         headers:
           Authorization: "Bearer {{ token }}"
         body_format: json
+        return_content: true
         body:
           query: '{{ lookup("template", "./deploy-no-sha.gql") }}'
         #body: '{ "query": "mutation($branchName: String!, $projectName: String!) {deployEnvironmentBranch(input:{branchName:$branchName,project:{name:$projectName}})}", "variables": {"branchName":"{{ branch }}","projectName":"{{ project }}"}}'
       register: apiresponse
-    - name: "{{ testname }} - POST api deployEnvironmentBranch with target git branch {{ branch }} and project {{ project }} (no sha) to {{ graphql_url }}"
-      debug:
-        msg: "api response: {{ apiresponse.json }}"
-      until: apiresponse.json.data.deployEnvironmentBranch == "success"
-      retries: 10
-      delay: 30
+    - name: Print apiresponse
+      ansible.builtin.debug:
+        msg: "api response: {{ apiresponse }}"
+    - fail:
+        msg: "unsuccessful deploy"
+      when: apiresponse.json.data.deployEnvironmentBranch != "success"
+    - name: "Set the retry count back to 0 when successful"
+      set_fact:
+        retry_count: 0
+  rescue:
+    - fail:
+        msg: Ended after 3 retries
+      when: retry_count|int == 3
+    - name: Pause for retry
+      pause:
+        seconds: 10
+    - debug:
+        msg: "Failed to connect - Retrying..."
+    - include_tasks: ./deploy-no-sha.yaml

--- a/tests/tasks/api/deploy-pullrequest.yaml
+++ b/tests/tasks/api/deploy-pullrequest.yaml
@@ -1,6 +1,9 @@
-- name: "{{ testname }} - POST api deployEnvironmentPullrequest with pr number {{ git_pr_number }}, git base branch {{ git_base_branch }}, base commit hash {{ git_base_commit_hash }}, pr branch {{ git_pr_branch }}, pr commit hash {{ git_pr_commit_hash }} to {{ graphql_url }}"
+- name: "Start deployEnvironmentPullrequest loop with 3 retries"
   block:
     - include: refresh-token.yaml
+    - name: "Set the retry count to {{ retry_count }}"
+      set_fact:
+        retry_count: "{{ 0 if retry_count is undefined else retry_count|int + 1 }}"
     - name: "{{ testname }} - POST api deployEnvironmentPullrequest with pr number {{ git_pr_number }}, git base branch {{ git_base_branch }}, base commit hash {{ git_base_commit_hash }}, pr branch {{ git_pr_branch }}, pr commit hash {{ git_pr_commit_hash }} to {{ graphql_url }}"
       uri:
         url: "{{ graphql_url }}"
@@ -8,10 +11,27 @@
         headers:
           Authorization: "Bearer {{ token }}"
         body_format: json
+        return_content: true
         body:
           query: '{{ lookup("template", "./deploy-pullrequest.gql") }}'
         # body: '{ "query": "mutation($projectName:String!, $number:Int!, $title:String!, $baseName:String!, $baseRef:String!, $headName:String!, $headRef:String!) {deployEnvironmentPullrequest(input:{project:{name:$projectName},number:$number,title:$title,baseBranchName:$baseName,baseBranchRef:$baseRef,headBranchName:$headName,headBranchRef:$headRef})}", "variables": {"projectName":"{{ project }}","number":{{ git_pr_number }},"title":"{{ git_pr_title }}","baseName":"{{ git_base_branch }}","baseRef":"{{ git_base_commit_hash }}","headName":"{{ git_pr_branch }}","headRef":"{{ git_pr_commit_hash }}"}}'
       register: apiresponse
-    - name: "{{ testname }} - POST api deployEnvironmentPullrequest with pr number {{ git_pr_number }}, git base branch {{ git_base_branch }}, base commit hash {{ git_base_commit_hash }}, pr branch {{ git_pr_branch }}, pr commit hash {{ git_pr_commit_hash }} to {{ graphql_url }}"
-      debug:
-        msg: "api response: {{ apiresponse.json }}"
+    - name: Print apiresponse
+      ansible.builtin.debug:
+        msg: "api response: {{ apiresponse }}"
+    - fail:
+        msg: "unsuccessful deploy"
+      when: apiresponse.json.data.deployEnvironmentPullrequest != "success"
+    - name: "Set the retry count back to 0 when successful"
+      set_fact:
+        retry_count: 0
+  rescue:
+    - fail:
+        msg: Ended after 3 retries
+      when: retry_count|int == 3
+    - name: Pause for retry
+      pause:
+        seconds: 10
+    - debug:
+        msg: "Failed to connect - Retrying..."
+    - include_tasks: ./deploy-pullrequest.yaml

--- a/tests/tasks/api/deploy-sha.yaml
+++ b/tests/tasks/api/deploy-sha.yaml
@@ -1,6 +1,9 @@
-- name: "{{ testname }} - POST api deployEnvironmentBranch with target git branch {{ branch }} and project {{ project }} and sha {{ sha }} to {{ graphql_url }}"
+- name: "Start deployEnvironmentBranch (SHA) loop with 3 retries"
   block:
     - include: refresh-token.yaml
+    - name: "Set the retry count to {{ retry_count }}"
+      set_fact:
+        retry_count: "{{ 0 if retry_count is undefined else retry_count|int + 1 }}"
     - name: "{{ testname }} - POST api deployEnvironmentBranch with target git branch {{ branch }} and project {{ project }} and sha {{ sha }} to {{ graphql_url }}"
       uri:
         url: "{{ graphql_url }}"
@@ -8,13 +11,27 @@
         headers:
           Authorization: "Bearer {{ token }}"
         body_format: json
+        return_content: true
         body:
           query: '{{ lookup("template", "./deploy-sha.gql") }}'
         # body: '{ "query": "mutation($branchName: String!, $branchRef: String!, $projectName: String!) {deployEnvironmentBranch(input:{branchName:$branchName,branchRef:$branchRef,project:{name:$projectName}})}", "variables": {"branchName":"{{ branch }}","branchRef":"{{ sha }}","projectName":"{{ project }}"}}'
       register: apiresponse
-    - name: "{{ testname }} - POST api deployEnvironmentBranch with target git branch {{ branch }} and project {{ project }} and sha {{ sha }} to {{ graphql_url }}"
-      debug:
-        msg: "api response: {{ apiresponse.json }}"
-      until: apiresponse.json.data.deployEnvironmentBranch == "success"
-      retries: 10
-      delay: 30
+    - name: Print apiresponse
+      ansible.builtin.debug:
+        msg: "api response: {{ apiresponse }}"
+    - fail:
+        msg: "unsuccessful deploy"
+      when: apiresponse.json.data.deployEnvironmentBranch != "success"
+    - name: "Set the retry count back to 0 when successful"
+      set_fact:
+        retry_count: 0
+  rescue:
+    - fail:
+        msg: Ended after 3 retries
+      when: retry_count|int == 3
+    - name: Pause for retry
+      pause:
+        seconds: 10
+    - debug:
+        msg: "Failed to connect - Retrying..."
+    - include_tasks: ./deploy-sha.yaml


### PR DESCRIPTION
The retry loop logic in testing would never actually trigger (owing to the graphql call via ansible.builtin.uri not actually failing)

This PR generates more debugging output, but also adds an explicit fail to trigger the loop