### PR TITLE
Declare DeployTargetConfig related api fields as unstable

### DIFF
--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -704,10 +704,8 @@ const typeDefs = gql`
     metadata: JSON
     """
     DeployTargetConfigs are a way to define which deploy targets are used for a project\n
-    *Important:* This is an alpha feature, and is subject to change in any release. Use this at your own risk\n
-    Ensure you stay up to date on changes that may occur with this feature
     """
-    deployTargetConfigs: [DeployTargetConfig]
+    deployTargetConfigs: [DeployTargetConfig] @deprecated(reason: "Unstable API, subject to breaking changes in any release. Use at your own risk")
   }
 
   """
@@ -1118,16 +1116,16 @@ const typeDefs = gql`
     """
     Returns the DeployTargetConfig by a deployTargetConfig Id
     """
-    deployTargetConfigById(id: Int!) : DeployTargetConfig
+    deployTargetConfigById(id: Int!) : DeployTargetConfig  @deprecated(reason: "Unstable API, subject to breaking changes in any release. Use at your own risk")
     """
     Returns all DeployTargetConfig by a project Id
     """
-    deployTargetConfigsByProjectId(project: Int!) : [DeployTargetConfig]
+    deployTargetConfigsByProjectId(project: Int!) : [DeployTargetConfig]  @deprecated(reason: "Unstable API, subject to breaking changes in any release. Use at your own risk")
     """
     Returns all DeployTargetConfig by a deployTarget Id (aka: Openshift Id)
     """
-    deployTargetConfigsByDeployTarget(deployTarget: Int!) : [DeployTargetConfig]
-    allDeployTargetConfigs: [DeployTargetConfig]
+    deployTargetConfigsByDeployTarget(deployTarget: Int!) : [DeployTargetConfig]  @deprecated(reason: "Unstable API, subject to breaking changes in any release. Use at your own risk")
+    allDeployTargetConfigs: [DeployTargetConfig]  @deprecated(reason: "Unstable API, subject to breaking changes in any release. Use at your own risk")
   }
 
   # Must provide id OR name
@@ -2002,10 +2000,10 @@ const typeDefs = gql`
     updateBillingModifier(input: UpdateBillingModifierInput!): BillingModifier
     deleteBillingModifier(input: DeleteBillingModifierInput!): String
     deleteAllBillingModifiersByBillingGroup(input: GroupInput!): String
-    addDeployTargetConfig(input: AddDeployTargetConfigInput!): DeployTargetConfig
-    updateDeployTargetConfig(input: UpdateDeployTargetConfigInput!): DeployTargetConfig
-    deleteDeployTargetConfig(input: DeleteDeployTargetConfigInput!): String
-    deleteAllDeployTargetConfigs: String
+    addDeployTargetConfig(input: AddDeployTargetConfigInput!): DeployTargetConfig  @deprecated(reason: "Unstable API, subject to breaking changes in any release. Use at your own risk")
+    updateDeployTargetConfig(input: UpdateDeployTargetConfigInput!): DeployTargetConfig  @deprecated(reason: "Unstable API, subject to breaking changes in any release. Use at your own risk")
+    deleteDeployTargetConfig(input: DeleteDeployTargetConfigInput!): String  @deprecated(reason: "Unstable API, subject to breaking changes in any release. Use at your own risk")
+    deleteAllDeployTargetConfigs: String  @deprecated(reason: "Unstable API, subject to breaking changes in any release. Use at your own risk")
   }
 
   type Subscription {


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->

<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

The GraphQL spec includes an `@deprecated` directive. All the dev tools I've tried are aware of this directive and will surface it in an explicit way. I think this would be a nicer way to warn users that the API is unstable.

Cons: it's maybe not correct to call it "deprecated" instead of unstable/alpha, but then all the dev tools wouldn't show that info.

Examples from dev tools:

Insomnia.app
<img width="639" alt="Fullscreen_10_18_21__5_51_PM" src="https://user-images.githubusercontent.com/92499/137818278-5204f86d-0d09-432a-90d1-a65f54aad40e.png">

GraphiQL
<img width="1209" alt="Fullscreen_10_18_21__6_07_PM" src="https://user-images.githubusercontent.com/92499/137818449-63827c28-08c4-4961-9044-3c1e44d5435d.png">

GraphQL Playground
<img width="920" alt="Fullscreen_10_18_21__6_10_PM" src="https://user-images.githubusercontent.com/92499/137818636-3c440cd8-c0ea-4c1e-b6f1-df1999ac86fe.png">


<!--
# Changelog Entry
Lagoon is using "Release Drafter" to create changelogs using PR titles and labels

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
Please ensure that this PR has the correct [0-9]-subsystem label(s) attached - this can be edited after merging if needed.
To skip changelog entry for this PR, use the `skip-changelog` label - ONLY do this for very minor changes - it will not appear in the release notes.
-->

# Closing issues

n/a
