### PR TITLE
Validate ingress annotation snippets against an allow-list

### DIFF
--- a/docs/using-lagoon-the-basics/lagoon-yml.md
+++ b/docs/using-lagoon-the-basics/lagoon-yml.md
@@ -262,7 +262,21 @@ When [UptimeRobot](https://uptimerobot.com/) is configured for your cluster \(Op
 Route/Ingress annotations are only supported by projects that deploy into clusters that run nginx-ingress controllers! Check with your Lagoon administrator if this is supported.
 {% endhint %}
 
-* `annotations` can be a yaml map of [annotations supported by the nginx-ingress controller](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/), this is specifically useful for easy redirects and other configurations
+* `annotations` can be a yaml map of [annotations supported by the nginx-ingress controller](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/), this is specifically useful for easy redirects and other configurations.
+
+#### **Restrictions**
+
+Some annotations are disallowed or partially restricted in Lagoon.
+The table below describes these rules.
+
+If your `.lagoon.yml` contains one of these annotations it will cause a build failure.
+
+| Annotation                                          | Notes                                                                                    |
+| ---                                                 | ---                                                                                      |
+| `nginx.ingress.kubernetes.io/auth-snippet`          | Disallowed                                                                               |
+| `nginx.ingress.kubernetes.io/configuration-snippet` | Restricted to `rewrite`, `add_header`, `set_real_ip`, and `more_set_headers` directives. |
+| `nginx.ingress.kubernetes.io/modsecurity-snippet`   | Disallowed                                                                               |
+| `nginx.ingress.kubernetes.io/server-snippet`        | Restricted to `rewrite`, `add_header`, `set_real_ip`, and `more_set_headers` directives. |
 
 #### **Ingress annotations redirects**
 

--- a/images/kubectl-build-deploy-dind/Dockerfile
+++ b/images/kubectl-build-deploy-dind/Dockerfile
@@ -20,4 +20,7 @@ COPY helmcharts  /kubectl-build-deploy/helmcharts
 
 ENV IMAGECACHE_REGISTRY=imagecache.amazeeio.cloud
 
+RUN curl -sSL https://github.com/uselagoon/lagoon-linter/releases/download/v0.3.0/lagoon-linter_0.3.0_linux_amd64.tar.gz \
+    | tar -xz -C /usr/local/bin lagoon-linter
+
 CMD ["/kubectl-build-deploy/build-deploy.sh"]

--- a/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
+++ b/images/kubectl-build-deploy-dind/build-deploy-docker-compose.sh
@@ -75,6 +75,13 @@ function featureFlag() {
 ### PREPARATION
 ##############################################
 
+# validate .lagoon.yml
+if ! lagoon-linter; then
+	echo "https://docs.lagoon.sh/lagoon/using-lagoon-the-basics/lagoon-yml#restrictions describes some possible reasons for this build failure."
+	echo "If you require assistance to fix this error, please contact support."
+	exit 1
+fi
+
 # Load path of docker-compose that should be used
 set +x # reduce noise in build logs
 DOCKER_COMPOSE_YAML=($(cat .lagoon.yml | shyaml get-value docker-compose-yaml))


### PR DESCRIPTION
This PR adds the [lagoon-linter](https://github.com/uselagoon/lagoon-linter) into the build and deploy process to ensure that only allowed ingress annotations snippets are allowed.

This monitors any `auth-snippet` `configuration-snippet` `modsecurity-snippet` and `server-snippet`, and only permits the following options:
- rewrite
- add_header
- set_real_ip_from
- more_set_headers

More information about ingress annotations is available at https://docs.lagoon.sh/lagoon/using-lagoon-the-basics/lagoon-yml#trusted-reverse-proxies