### PR TITLE
chore: adds fix-key-perms to set sshkey perms correctly for local-dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -347,6 +347,13 @@ down:
 kill:
 	docker ps --format "{{.Names}}" | grep lagoon | xargs -t -r -n1 docker rm -f -v
 
+.PHONY: fix-key-perms
+fix-key-perms:
+	chmod 600 ./local-dev/sshkey-maintainer-ecdsa
+	chmod 600 ./local-dev/sshkey-platform-owner-ed25519
+	chmod 600 ./local-dev/sshkey-ci-customer-user-rsa
+	ls -al ./local-dev/sshkey-*
+
 .PHONY: local-dev-yarn
 local-dev-yarn:
 	$(MAKE) local-dev-yarn-stop


### PR DESCRIPTION
This PR implements a make routine to set the correct 600 permission on the local-dev SSH private keys. Github stores files as 644 by default, so the private keys need to be chmodded to 600 before they can be used for SSH'ing.

Given how rarely this is needed, I've not added the routine to any others, and kept it standalone