### PR TITLE
build: update keycloak and dependencies to 25.0.6

### DIFF
--- a/services/api/package.json
+++ b/services/api/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "@lagoon/commons": "4.0.0",
-    "@s3pweb/keycloak-admin-client-cjs": "^25.0.2",
+    "@s3pweb/keycloak-admin-client-cjs": "^25.1.0",
     "@supercharge/request-ip": "^1.1.2",
     "apollo-server-express": "^2.14.2",
     "aws-sdk": "^2.378.0",

--- a/services/keycloak/Dockerfile
+++ b/services/keycloak/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.8.2-jdk-11 as builder
+FROM maven:3.9.9-eclipse-temurin-21-alpine as builder
 # build the custom token mapper in builder
 COPY custom-mapper/. .
 RUN mvn clean compile package
@@ -17,7 +17,7 @@ COPY javascript /tmp/lagoon-scripts
 
 RUN cd /tmp/lagoon-scripts && zip -r ../lagoon-scripts.jar *
 
-FROM quay.io/keycloak/keycloak:24.0.5
+FROM quay.io/keycloak/keycloak:25.0.6
 COPY --from=ubi-micro-build /mnt/rootfs /
 
 ARG LAGOON_VERSION
@@ -86,7 +86,7 @@ COPY entrypoints/default-keycloak-entrypoint.sh /lagoon/entrypoints/99-default-k
 COPY startup-scripts /opt/keycloak/startup-scripts
 COPY themes/lagoon /opt/keycloak/themes/lagoon
 COPY --from=commons /tmp/lagoon-scripts.jar /opt/keycloak/providers/lagoon-scripts.jar
-COPY --from=builder /target/custom-protocol-mapper-1.0.0.jar /opt/keycloak/providers/custom-protocol-mapper-1.0.0.jar
+COPY --from=builder /target/custom-protocol-mapper-1.1.0.jar /opt/keycloak/providers/custom-protocol-mapper-1.1.0.jar
 
 COPY lagoon-realm-base-import.json /lagoon/seed/lagoon-realm-base-import.json
 

--- a/services/keycloak/custom-mapper/pom.xml
+++ b/services/keycloak/custom-mapper/pom.xml
@@ -6,11 +6,11 @@
 
     <groupId>net.cake.keycloak.custom</groupId>
     <artifactId>custom-protocol-mapper</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <properties>
-        <keycloak.version>17.0.1</keycloak.version>
+        <keycloak.version>25.0.6</keycloak.version>
     </properties>
 
     <dependencies>
@@ -52,7 +52,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
+                <version>3.13.0</version>
                 <configuration>
                     <forceJavacCompilerUse>true</forceJavacCompilerUse>
                     <source>1.8</source>
@@ -62,7 +62,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.6.0</version>
                 <executions>
                     <!-- Run shade goal on package phase -->
                     <execution>

--- a/yarn.lock
+++ b/yarn.lock
@@ -703,10 +703,10 @@
   resolved "https://registry.yarnpkg.com/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz#9299f82874bab9e4c7f9c48d865becbfe8d6907c"
   integrity sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==
 
-"@keycloak/keycloak-admin-client@25.0.4":
-  version "25.0.4"
-  resolved "https://registry.yarnpkg.com/@keycloak/keycloak-admin-client/-/keycloak-admin-client-25.0.4.tgz#2ec46bab133cc807df78ffd7ca7bba47ec8ed000"
-  integrity sha512-mZVFwly7cHZq1XpvJrrOutU0qrUbGo8NUdpb7PS4309x8yG2a4/WyZfh2lgiopBRQ6R/b24RsuHa4GetQPqT+g==
+"@keycloak/keycloak-admin-client@25.0.6":
+  version "25.0.6"
+  resolved "https://registry.yarnpkg.com/@keycloak/keycloak-admin-client/-/keycloak-admin-client-25.0.6.tgz#3a4ade427a237ff70ced2825a88c56b1a4aec6c6"
+  integrity sha512-rUvo6L0aT9+y/R2wFhDKb+lRD5rwj36XwnIGIbmC2HeQVfgroYB5u/79yc/Mo0inBFNIG8VuiwjRzU878fRE0Q==
   dependencies:
     camelize-ts "^3.0.0"
     url-join "^5.0.0"
@@ -926,12 +926,12 @@
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
-"@s3pweb/keycloak-admin-client-cjs@^25.0.2":
-  version "25.0.4"
-  resolved "https://registry.yarnpkg.com/@s3pweb/keycloak-admin-client-cjs/-/keycloak-admin-client-cjs-25.0.4.tgz#925aa0f780233992e44d09a1efbfcbf4718f924a"
-  integrity sha512-0qQYvmftr4rZKO1JuDq077odNwQ8rS/FGlvBOSOoncvM2i7HljEHvMcsAHR3gNrOkawVlPoYwA+zZdtHICIU4A==
+"@s3pweb/keycloak-admin-client-cjs@^25.1.0":
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/@s3pweb/keycloak-admin-client-cjs/-/keycloak-admin-client-cjs-25.1.0.tgz#497b401c276a0f7b9309df0d035af4c17e66ace1"
+  integrity sha512-0ptQA0Wf+JxbNxd1vrVfhnLEjbJun/dVYB+YMz0xhtNQJxYy6wYWABZnVz+bKu23F2HsKYm8tXSyGuBrCRvWOA==
   dependencies:
-    "@keycloak/keycloak-admin-client" "25.0.4"
+    "@keycloak/keycloak-admin-client" "25.0.6"
 
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"


### PR DESCRIPTION
Current blocker:

Fails on JWT validation
```
TASK [debug] *******************************************************************

Wednesday 02 October 2024  02:41:13 +0000 (0:00:00.170)       0:00:04.390 ***** 

ok: [localhost] => {

    "msg": "refresh token stdout: {\"error\":\"invalid_grant\",\"error_description\":\"Invalid token issuer. Expected '[http://lagoon-core-keycloak:8080/auth/realms/lagoon'\"}\n](http://lagoon-core-keycloak:8080/auth/realms/lagoon'/%22%7D/n)"

}



TASK [debug] *******************************************************************

Wednesday 02 October 2024  02:41:13 +0000 (0:00:00.017)       0:00:04.408 ***** 

ok: [localhost] => {

    "msg": "refresh token stderr: "

}



TASK [set_fact] ****************************************************************

Wednesday 02 October 2024  02:41:13 +0000 (0:00:00.021)       0:00:04.429 ***** 

fatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'access_token'\n\nThe error appears to be in '/ansible/tasks/api/refresh-token.yaml': line 10, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n        msg: \"refresh token stderr: {{ grant.stderr }}\"\n    - set_fact:\n      ^ here\n"}
```

Presumably because of https://www.keycloak.org/docs/25.0.0/upgrading/#new-hostname-options