### PR TITLE
feat: add keycloak plugin for better SSO UX

### DIFF
--- a/local-dev/k3d-seed-data/seed-example-sso.sh
+++ b/local-dev/k3d-seed-data/seed-example-sso.sh
@@ -2,6 +2,7 @@
 
 CONFIG_PATH=/tmp/kcadm.config
 
+function auth {
 # login to keycloak
 if ! /opt/keycloak/bin/kcadm.sh config credentials --config $CONFIG_PATH --server http://localhost:8080/auth --realm master --client admin-api --secret ${KEYCLOAK_ADMIN_API_CLIENT_SECRET}
 then
@@ -12,6 +13,9 @@ then
    exit 1
    fi
 fi
+}
+
+auth
 
 if /opt/keycloak/bin/kcadm.sh get realms/sso --config $CONFIG_PATH > /dev/null; then
     echo "Realm sso is already created, skipping"
@@ -21,6 +25,9 @@ fi
 # create the SSO realm
 echo "Creating new sso realm"
 /opt/keycloak/bin/kcadm.sh create realms --config $CONFIG_PATH -s realm=sso -s enabled=true
+
+# must reauth to get permissions for new realm
+auth
 
 # Create a user in the SSO realm
 

--- a/local-dev/k3d-seed-data/seed-example-sso.sh
+++ b/local-dev/k3d-seed-data/seed-example-sso.sh
@@ -2,24 +2,24 @@
 
 CONFIG_PATH=/tmp/kcadm.config
 
-function auth {
 # login to keycloak
-if ! /opt/keycloak/bin/kcadm.sh config credentials --config $CONFIG_PATH --server http://localhost:8080/auth --realm master --client admin-api --secret ${KEYCLOAK_ADMIN_API_CLIENT_SECRET}
-then
-   if ! /opt/keycloak/bin/kcadm.sh config credentials --config $CONFIG_PATH --server http://localhost:8080/auth --user $KEYCLOAK_ADMIN_USER --password $KEYCLOAK_ADMIN_PASSWORD --realm master
-   then
-   echo "Unable to log in to keycloak with client admin-api or username and password"
-   echo "If you have rotated the admin-api secret, you will need to log in and update it manually"
-   exit 1
-   fi
-fi
+function auth {
+  if ! /opt/keycloak/bin/kcadm.sh config credentials --config $CONFIG_PATH --server http://localhost:8080/auth --realm master --client admin-api --secret ${KEYCLOAK_ADMIN_API_CLIENT_SECRET}
+  then
+    if ! /opt/keycloak/bin/kcadm.sh config credentials --config $CONFIG_PATH --server http://localhost:8080/auth --user $KEYCLOAK_ADMIN_USER --password $KEYCLOAK_ADMIN_PASSWORD --realm master
+    then
+      echo "Unable to log in to keycloak with client admin-api or username and password"
+      echo "If you have rotated the admin-api secret, you will need to log in and update it manually"
+      exit 1
+    fi
+  fi
 }
 
 auth
 
 if /opt/keycloak/bin/kcadm.sh get realms/sso --config $CONFIG_PATH > /dev/null; then
-    echo "Realm sso is already created, skipping"
-    exit 0
+  echo "Realm sso is already created, skipping"
+  exit 0
 fi
 
 # create the SSO realm
@@ -33,20 +33,20 @@ auth
 
 echo "Creating user and configuring password for user@sso.example.com"
 /opt/keycloak/bin/kcadm.sh create users -r sso \
-   -s email=user@sso.example.com \
-   -s firstName=sso \
-   -s lastName=user \
-   -s username=sso-user \
-   -s enabled=true \
-   -o --fields id,username \
-   --config $CONFIG_PATH
+  -s email=user@sso.example.com \
+  -s firstName=sso \
+  -s lastName=user \
+  -s username=sso-user \
+  -s enabled=true \
+  -o --fields id,username \
+  --config $CONFIG_PATH
 
 # Set the password for the SSO user
 /opt/keycloak/bin/kcadm.sh set-password \
-   --config $CONFIG_PATH \
-   --username sso-user \
-   -p user@sso.example.com \
-   --target-realm sso
+  --config $CONFIG_PATH \
+  --username sso-user \
+  -p user@sso.example.com \
+  --target-realm sso
 
 # create the SSO realm OIDC client
 echo "Creating example client in sso realm"
@@ -82,9 +82,9 @@ echo "Creating ssorealm identity provider in lagoon realm"
 # create a role mapper that grants any users from the SSO realm as platform-owner
 echo "Configuring ssorealm identity provider with platform-owner role mapping"
 /opt/keycloak/bin/kcadm.sh create identity-provider/instances/ssorealm/mappers \
-   -s name=platform-owner \
-   -s identityProviderMapper=oidc-hardcoded-role-idp-mapper  \
-   -s identityProviderAlias=ssorealm \
-   -s config.syncMode=FORCE \
-   -s config.role=platform-owner \
-    --config $CONFIG_PATH -r lagoon
+  -s name=platform-owner \
+  -s identityProviderMapper=oidc-hardcoded-role-idp-mapper  \
+  -s identityProviderAlias=ssorealm \
+  -s config.syncMode=FORCE \
+  -s config.role=platform-owner \
+  --config $CONFIG_PATH -r lagoon

--- a/local-dev/k3d-seed-data/seed-example-sso.sh
+++ b/local-dev/k3d-seed-data/seed-example-sso.sh
@@ -67,7 +67,10 @@ echo "Creating ssorealm identity provider in lagoon realm"
   -s config.logoutUrl=${KEYCLOAK_FRONTEND_URL%/}/realms/sso/protocol/openid-connect/logout \
   -s config.userInfoUrl=http://localhost:8080/auth/realms/sso/protocol/openid-connect/userinfo \
   -s config.issuer=${KEYCLOAK_FRONTEND_URL%/}/realms/sso \
+  -s config.loginHint=true \
   -s config.validateSignature=true \
+  -s 'config."home.idp.discovery.domains"=sso.example.com' \
+  -s 'config."home.idp.discovery.matchSubdomains"=true' \
   -s config.pkceEnabled=false \
   -s config.clientAuthMethod=client_secret_post \
   -s config.clientId=sso-oidc-client \

--- a/services/keycloak/Dockerfile
+++ b/services/keycloak/Dockerfile
@@ -82,6 +82,8 @@ ENV TMPDIR=/tmp \
 
 VOLUME /opt/keycloak/data
 
+RUN curl -sSLo /opt/keycloak/providers/keycloak-home-idp-discovery.jar https://github.com/sventorben/keycloak-home-idp-discovery/releases/download/v26.0.1/keycloak-home-idp-discovery.jar
+
 COPY entrypoints/kc-startup.sh /lagoon/kc-startup.sh
 COPY entrypoints/wait-for-mariadb.sh /lagoon/entrypoints/98-wait-for-mariadb.sh
 COPY entrypoints/default-keycloak-entrypoint.sh /lagoon/entrypoints/99-default-keycloak-entrypoint.sh

--- a/services/keycloak/README.md
+++ b/services/keycloak/README.md
@@ -1,0 +1,15 @@
+# Keycloak
+
+Lagoon uses Keycloak to store users, handle authentication and authorization for multiple clients
+(api, ui, cli, etc), and handle SSO against 3rd party identity providers.
+
+## Upgrading
+
+Upgrading keycloak should not be done without care. Carefully read the release and upgrade notes to
+determine if any breaking changes have been made to subsystems that Lagoon relies on. This includes
+how Keycloak is configured and run.
+
+The following libraries/plugins may also require specific versions of Keycloak, or must be upgraded
+at the same time as Keycloak to a supported version:
+
+* [Home IDP Discovery plugin](https://github.com/sventorben/keycloak-home-idp-discovery)


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

Adds a [keycloak plugin](https://sventorben.github.io/keycloak-home-idp-discovery/) that can detect which identity provider to use based on the user email address, instead of forcing the user to select their own provider.

Configuration of the login flow is manual for this PR, there is an example at https://sventorben.github.io/keycloak-home-idp-discovery/configuration.html#authenticator-execution.

For local testing, you can run `make compose/example-sso` and then create a new login flow for the `lagoon` realm. Note that the lagoon theme is quite out of date and doesn't work well with the new flow.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->
