### PR TITLE
fix: addOrganization mutation fails when optional description is not provided

### DIFF
--- a/services/api/src/resources/organization/sql.ts
+++ b/services/api/src/resources/organization/sql.ts
@@ -5,7 +5,7 @@ export const Sql = {
     id,
     name,
     friendlyName = name, // default to name if not provided
-    description,
+    description = "",
     quotaProject,
     quotaGroup,
     quotaNotification,


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Database Migrations

n/a

# Description

The API schema has `description` as an optional field when adding an organization, but not providing it throws an error:

```
mutation {
  addOrganization(input: {
    name: "test"
  }) {
    id
    name
    description
  }
}
```
```
{
  "errors": [
    {
      "message": "There was an error creating the organization test Error: (conn=427, no: 1364, SQLState: HY000) Field 'description' doesn't have a default value\nsql: insert into `organization` (`description`, `friendly_name`, `id`, `name`, `quota_environment`, `quota_group`, `quota_notification`, `quota_project`, `quota_route`) values (DEFAULT, 'test', DEFAULT, 'test', DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT) - parameters:{}",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "addOrganization"
      ],
      "extensions": {
        "code": "INTERNAL_SERVER_ERROR",
        "exception": {
          "stacktrace": [
            "Error: There was an error creating the organization test Error: (conn=427, no: 1364, SQLState: HY000) Field 'description' doesn't have a default value",
            "sql: insert into `organization` (`description`, `friendly_name`, `id`, `name`, `quota_environment`, `quota_group`, `quota_notification`, `quota_project`, `quota_route`) values (DEFAULT, 'test', DEFAULT, 'test', DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT) - parameters:{}",
            "    at /app/services/api/dist/resources/organization/resolvers.js:91:15",
            "    at Generator.throw (<anonymous>)",
            "    at rejected (/app/services/api/dist/resources/organization/resolvers.js:29:65)",
            "    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)"
          ]
        }
      }
    }
  ],
  "data": {
    "addOrganization": null
  }
}
```

Looks like an issue caused by the changes in default values of database columns in #3816.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

n/a
