### PR TITLE
fix: groups with greater than 100 members

### DIFF
--- a/services/api/src/clients/redisClient.ts
+++ b/services/api/src/clients/redisClient.ts
@@ -40,9 +40,5 @@ redisClient.on('error', function (error) {
   console.error(error);
 });
 
-export const groupCacheExpiry = toNumber(
-  getConfigFromEnv('REDIS_GROUP_CACHE_EXPIRY', '172800'),
-);
-
 export const get = promisify(redisClient.get).bind(redisClient);
 export const del = promisify(redisClient.del).bind(redisClient);

--- a/services/api/src/models/group.ts
+++ b/services/api/src/models/group.ts
@@ -593,6 +593,7 @@ export const Group = (clients: {
         const keycloakUsers = await keycloakAdminClient.groups.listMembers({
           id: roleSubgroup.id,
           briefRepresentation: false,
+          max: -1,
         });
 
         let members = [];


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Database Migrations

n/a

# Description

In Keycloak 23, the API was updated to page results, with a default limit of `100` results for group member listings. When upgrading keycloak, this was not taken into account, so Lagoon groups with greater than 100 members are not able to list all members, and users outside the limit don't get the correct permissions.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

n/a
