### PR TITLE
tests: adds the ability to check url content for two options

### DIFF
--- a/tests/checks/check-url-content.yaml
+++ b/tests/checks/check-url-content.yaml
@@ -5,7 +5,7 @@
     return_content: yes
     validate_certs: no
   register: result
-  until: result.content is search(expected_content)
+  until: result.content is search(expected_content) or result.content is search(expected_content_alt | default(false))
   retries: 90
   delay: 20
 - name: "{{ testname }} - Check if URL {{ url }} contains content {{ expected_content }}"

--- a/tests/checks/check-url-content.yaml
+++ b/tests/checks/check-url-content.yaml
@@ -5,7 +5,7 @@
     return_content: yes
     validate_certs: no
   register: result
-  until: result.content is search(expected_content) or result.content is search(expected_content_alt | default(false))
+  until: result.content is search(expected_content) or result.content is search(expected_content_alt | default(''))
   retries: 90
   delay: 20
 - name: "{{ testname }} - Check if URL {{ url }} contains content {{ expected_content }}"

--- a/tests/tests/features/route-env-variables.yaml
+++ b/tests/tests/features/route-env-variables.yaml
@@ -32,7 +32,8 @@
   serial: 1
   vars:
     url: "{{ check_url }}"
-    expected_content: "LAGOON_ROUTES=https://customdomain-will-be-main-domain.com,https://customdomain-will-be-not-be-main-domain.com,https://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','ROUTE_SUFFIX_HTTPS') }}"
+    expected_content: "LAGOON_ROUTES=https://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','ROUTE_SUFFIX_HTTPS') }},https://customdomain-will-be-main-domain.com,https://customdomain-will-be-not-be-main-domain.com"
+    expected_content_alt: "LAGOON_ROUTES=https://customdomain-will-be-main-domain.com,https://customdomain-will-be-not-be-main-domain.com,https://node.{{ project | regex_replace('_', '-') }}.{{ branch | regex_replace('/', '-') }}.{{ lookup('env','ROUTE_SUFFIX_HTTPS') }}"
   tasks:
   - ansible.builtin.include_tasks: ../../checks/check-url-content.yaml
 


### PR DESCRIPTION
With a recent change, the order of the routes returned in LAGOON_ROUTES changed, and this broke the test suite.

In this PR I have added both variants to the check-url-content routine, just in case we need to go back to the previous version.

Note: active-standby-kubernetes test failure is expected here temporarily