### PR TITLE
fix: error when updating advanced task commands without changing the command

### DIFF
--- a/services/api/src/resources/task/task_definition_resolvers.ts
+++ b/services/api/src/resources/task/task_definition_resolvers.ts
@@ -448,7 +448,7 @@ export const updateAdvancedTaskDefinition = async (
   // we will merge the patch into the advanced task to double check that the final data is still valid
   task = {...task, ...patch};
 
-  validateAdvancedTaskDefinitionData(task, image, command, type);
+  validateAdvancedTaskDefinitionData(task, task.image, task.command, task.type);
 
   //We actually don't want them to be able to update group, project, environment - so those aren't
   await query(


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Database Migrations

n/a

# Description

Attempting to update a command advanced task throws an error if the command field isn't included in the `patch` input: 
> Unable to create Advanced task definition - no command provided

```graphql
mutation {
  updateAdvancedTaskDefinition(input: {
    id: 2008
    patch: {
      projectKeyInjection: true
    }
  }) {
    ... on AdvancedTaskDefinitionCommand {
      id
      name
      command
      projectKeyInjection
    }
  }
}

{
  "errors": [
    {
      "message": "Unable to create Advanced task definition - no command provided",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "updateAdvancedTaskDefinition"
      ]
    }
  ],
  "data": {
    "updateAdvancedTaskDefinition": null
  }
}
```

This PR makes the command field optional when updating advanced tasks.

## Workaround
Just include the `command` without changing it.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

n/a