### PR TITLE
fix: removeUserFromGroup cache duplicates when user not in group

### DIFF
--- a/node-packages/commons/src/util/func.ts
+++ b/node-packages/commons/src/util/func.ts
@@ -50,6 +50,18 @@ export const encodeJSONBase64 = (data: any): string =>
 export const decodeJSONBase64 = (data: string): any =>
   JSON.parse(decodeBase64(data));
 
+export const getErrorMessage = (err: unknown): string => {
+  let msg = `unknown error (${typeof err})`;
+
+  if (err instanceof Error) {
+    msg = err.message;
+  } else if (typeof err === 'string') {
+    msg = err;
+  }
+
+  return msg;
+}
+
 interface PublicKeyResponse {
   error?: string;
   publickey?: string;


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Database Migrations

n/a

# Description

Running the `removeUserFromGroup` mutation, when the user isn't a member of the group, causes the group member cache to balloon in size. There was a bug that caused the entire member list to be appended instead of being reset each time it is called.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

n/a
