### PR TITLE
docs: `mongo` service type is now called `mongodb`

### DIFF
--- a/docs/concepts-advanced/service-types.md
+++ b/docs/concepts-advanced/service-types.md
@@ -100,15 +100,15 @@ Uses a shared MariaDB server via the DBaaS Operator.
 | :--- | :--- | :--- | :--- | :--- |
 | Not Needed | `3306` | No | - | - |
 
-## `mongo`
+## `mongodb`
 
-A meta-service which will tell Lagoon to automatically decide between `mongo-single` and `mongo-dbaas`.
+A meta-service which will tell Lagoon to automatically decide between `mongodb-single` and `mongodb-dbaas`.
 
 | Healthcheck | Exposed Ports | Auto Generated Routes | Storage | Docker compose labels |
 | :--- | :--- | :--- | :--- | :--- |
 | - | - | - | - | - |
 
-## `mongo-single`
+## `mongodb-single`
 
 MongoDB container, will generate persistent storage of min 1GB mounted at `/data/db`.
 
@@ -116,7 +116,7 @@ MongoDB container, will generate persistent storage of min 1GB mounted at `/data
 | :--- | :--- | :--- | :--- | :--- |
 | TCP connection on `27017` | `27017` | No | [Block](./storage-types.md#block) | `lagoon.persistent.size` |
 
-## `mongo-dbaas`
+## `mongodb-dbaas`
 
 Uses a shared MongoDB server via the DBaaS Operator.
 

--- a/docs/ja/concepts-advanced/service-types.md
+++ b/docs/ja/concepts-advanced/service-types.md
@@ -85,15 +85,15 @@ DBaaSオペレーターを介した共有MariaDBサーバーを使用します�
 | :--- | :--- | :--- | :--- | :--- |
 | 不要 | `3306` | なし | - | - |
 
-## `mongo`
+## `mongodb`
 
-Lagoonに`mongo-single`と`mongo-dbaas`のどちらかを自動的に決定させるメタサービス。
+Lagoonに`mongodb-single`と`mongodb-dbaas`のどちらかを自動的に決定させるメタサービス。
 
 | ヘルスチェック | 公開ポート | 自動生成ルート | ストレージ | 追加のカスタマイズパラメータ |
 | :--- | :--- | :--- | :--- | :--- |
 | - | - | - | - | - |
 
-## `mongo-single`
+## `mongodb-single`
 
 MongoDBコンテナ、`/data/db`にマウントされた最小1GBの永続ストレージを生成します。
 
@@ -101,7 +101,7 @@ MongoDBコンテナ、`/data/db`にマウントされた最小1GBの永続スト
 | :--- | :--- | :--- | :--- | :--- |
 | `27017`でTCP接続 | `27017` | なし | はい | `lagoon.persistent.size` |
 
-## `mongo-dbaas`
+## `mongodb-dbaas`
 
 DBaaSオペレーターを介した共有MongoDBサーバーを使用します。
 


### PR DESCRIPTION
# Description

The docs use `mongo` for the service type name, but the build-deploy-tool uses `mongodb`.

See also https://github.com/uselagoon/build-deploy-tool/pull/432