### PR TITLE
docs: document valkey and redis-8 Lagoon images

### DIFF
--- a/docs/concepts-advanced/service-types.md
+++ b/docs/concepts-advanced/service-types.md
@@ -252,6 +252,22 @@ Solr container with auto-generated persistent storage mounted under `/var/solr`.
 | :--- | :--- | :--- | :--- | :--- |
 | TCP connection on `8983` | `8983` | No | [Block](./storage-types.md#block) | `lagoon.persistent.size` |
 
+## `valkey`
+
+Valkey container.
+
+| Healthcheck | Exposed Ports | Auto Generated Routes | Storage | Docker compose labels |
+| :--- | :--- | :--- | :--- | :--- |
+| TCP connection on `6379` | `6379` | No | No | - |
+
+## `valkey-persistent`
+
+Valkey container with auto-generated persistent storage mounted under `/data`.
+
+| Healthcheck | Exposed Ports | Auto Generated Routes | Storage | Docker compose labels |
+| :--- | :--- | :--- | :--- | :--- |
+| TCP connection on `6379` | `6379` | No | [Block](./storage-types.md#block) | `lagoon.persistent.size` |
+
 ## `varnish`
 
 Varnish container.

--- a/docs/docker-images/mariadb.md
+++ b/docs/docker-images/mariadb.md
@@ -2,17 +2,23 @@
 
 MariaDB is the open source successor to MySQL.
 
-The [Lagoon `MariaDB` image Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/mariadb/10.6.Dockerfile). Based on the official packages [`mariadb`](https://pkgs.alpinelinux.org/packages?name=mariadb&branch=edge) and [`mariadb-client`](https://pkgs.alpinelinux.org/packages?name=mariadb-client&branch=edge) provided by the the upstream Alpine image.
+The [Lagoon `MariaDB` image Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/mariadb/10.6.Dockerfile).
+
+10.6 and 10.11 images are based on the official packages [`mariadb`](https://pkgs.alpinelinux.org/packages?name=mariadb&branch=edge) and [`mariadb-client`](https://pkgs.alpinelinux.org/packages?name=mariadb-client&branch=edge) provided by the the upstream Alpine image.
+
+11.4 onwards LTS images are based on the official upstream docker image [`mariadb`](https://hub.docker.com/_/mariadb) (ubi9 variant).
 
 This Dockerfile is intended to be used to set up a standalone MariaDB database server.
 
 * 10.4 \(available for compatibility only, no longer officially supported\) - `uselagoon/mariadb-10.4`
-* 10.5 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/mariadb/10.5.Dockerfile) (Alpine 3.14 Support until May 2023) - `uselagoon/mariadb-10.5`
+* 10.4 \(available for compatibility only, no longer officially supported\) - `uselagoon/mariadb-10.5`
 * 10.6 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/mariadb/10.6.Dockerfile) (Alpine 3.16 Support until May 2024) - `uselagoon/mariadb-10.6`
 * 10.11 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/mariadb/10.11.Dockerfile) (Alpine 3.18 Support until May 2025) - `uselagoon/mariadb-10.11`
+* 11.4 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/mariadb/11.4.Dockerfile) (MariaDB 11.4 Support until May 2029) - `uselagoon/mariadb-10.11`
 
 !!! Info
-    As these images are not built from the upstream MariaDB images, their support follows a different cycle - and will only receive updates as long as the underlying Alpine images receive support - see [https://alpinelinux.org/releases/](https://alpinelinux.org/releases/) for more information. In practice, most MariaDB users will only be running these containers locally - the production instances will use the Managed Cloud Databases provided by the DBaaS Operator
+    As the 10.6 and 10.11 images are not built from the upstream MariaDB images, their support follows a different cycle - and will only receive updates as long as the underlying Alpine images receive support - see [https://alpinelinux.org/releases/](https://alpinelinux.org/releases/) for more information. In practice, most MariaDB users will only be running these containers locally - the production instances will use the Managed Cloud Databases provided by the DBaaS Operator
+    From 11.4 onwards, we stop updating EOL images usually with the Lagoon release that comes after the officially communicated EOL date: [https://mariadb.com/kb/en/mariadb-server-release-dates/](https://mariadb.com/kb/en/mariadb-server-release-dates/).
 
 ## Lagoon adaptions
 
@@ -29,7 +35,7 @@ This image is prepared to be used on Lagoon. There are therefore some things alr
 
 ```yaml title="docker-compose.yml"
 	mariadb:
-		image: uselagoon/mariadb-10.6-drupal:latest
+		image: uselagoon/mariadb-10.6:latest
 		labels:
 		# tells Lagoon this is a MariaDB database
 			lagoon.type: mariadb
@@ -76,3 +82,24 @@ variables](../concepts-advanced/environment-variables.md).
 If the `LAGOON_ENVIRONMENT_TYPE` variable is set to `production`, performances
 are set accordingly by using `MARIADB_INNODB_BUFFER_POOL_SIZE=1024` and
 `MARIADB_INNODB_LOG_FILE_SIZE=256`.
+
+## `docker-compose.yml` snippet for Drupal projects built on MariaDB 11.4
+
+For 11.4 onwards no drupal-specific variant has been published. To ensure backward compatibility, you will need to manually set the environment variables in your docker-compose.yml
+```yaml title="docker-compose.yml"
+	mariadb:
+		image: uselagoon/mariadb-11.4:latest
+		labels:
+		# tells Lagoon this is a MariaDB database
+			lagoon.type: mariadb
+		ports:
+			# exposes the port 3306 with a random local port, find it with `docker compose port mariadb 3306`
+			- "3306"
+    environment:
+      MARIADB_DATABASE: drupal # the name of the database to create
+      MARIADB_USER: drupal # the user to create
+      MARIADB_PASSWORD: drupal # the password for the user
+		volumes:
+			# mounts a named volume at the default path for MariaDB
+			- db:/var/lib/mysql
+```

--- a/docs/docker-images/opensearch.md
+++ b/docs/docker-images/opensearch.md
@@ -7,6 +7,7 @@
 ## Supported versions
 
 * 2 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/opensearch/2.Dockerfile) - `uselagoon/opensearch-2`
+* 3 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/opensearch/3.Dockerfile) - `uselagoon/opensearch-3`
 
 ## Environment Variables
 

--- a/docs/docker-images/php-cli.md
+++ b/docs/docker-images/php-cli.md
@@ -14,9 +14,11 @@ The image also contains database `cli`s for both MariaDB and PostgreSQL.
 * 7.3 \(available for compatibility only, no longer officially supported\) - `uselagoon/php-7.3-cli`
 * 7.4 \(available for compatibility only, no longer officially supported\) - `uselagoon/php-7.4-cli`
 * 8.0 \(available for compatibility only, no longer officially supported\) - `uselagoon/php-8.0-cli`
-* 8.1 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/php-cli/8.1.Dockerfile) (Security Support until November 2024) - `uselagoon/php-8.1-cli`
-* 8.2 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/php-cli/8.2.Dockerfile) (Security Support until December 2025) - `uselagoon/php-8.2-cli`
-* 8.3 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/php-cli/8.3.Dockerfile) (Security Support until December 2026) - `uselagoon/php-8.3-cli`
+* 8.1 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/php-cli/8.1.Dockerfile) (Security Support until December 2025) - `uselagoon/php-8.1-cli`
+* 8.2 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/php-cli/8.2.Dockerfile) (Security Support until December 2026) - `uselagoon/php-8.2-cli`
+* 8.3 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/php-cli/8.3.Dockerfile) (Security Support until December 2027) - `uselagoon/php-8.3-cli`
+* 8.4 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/php-cli/8.4.Dockerfile) (Security Support until December 2028) - `uselagoon/php-8.4-cli`
+
 
 All PHP versions use their own Dockerfiles.
 

--- a/docs/docker-images/php-fpm.md
+++ b/docs/docker-images/php-fpm.md
@@ -16,9 +16,11 @@ The [Lagoon `php-fpm` Docker image](https://github.com/uselagoon/lagoon-images/b
 * 7.3 \(available for compatibility only, no longer officially supported\) - `uselagoon/php-7.3-fpm`
 * 7.4 \(available for compatibility only, no longer officially supported\) - `uselagoon/php-7.4-fpm`
 * 8.0 \(available for compatibility only, no longer officially supported\) - `uselagoon/php-8.0-fpm`
-* 8.1 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/php-fpm/8.1.Dockerfile) (Security Support until November 2024) - `uselagoon/php-8.1-fpm`
-* 8.2 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/php-fpm/8.2.Dockerfile) (Security Support until December 2025) - `uselagoon/php-8.2-fpm`
-* 8.3 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/php-fpm/8.3.Dockerfile) (Security Support until December 2026) - `uselagoon/php-8.3-fpm`
+* 8.1 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/php-fpm/8.1.Dockerfile) (Security Support until December 2025) - `uselagoon/php-8.1-fpm`
+* 8.2 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/php-fpm/8.2.Dockerfile) (Security Support until December 2026) - `uselagoon/php-8.2-fpm`
+* 8.3 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/php-fpm/8.3.Dockerfile) (Security Support until December 2027) - `uselagoon/php-8.3-fpm`
+* 8.4 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/php-fpm/8.4.Dockerfile) (Security Support until December 2028) - `uselagoon/php-8.4-fpm`
+
 
 All PHP versions use their own Dockerfiles.
 

--- a/docs/docker-images/postgres.md
+++ b/docs/docker-images/postgres.md
@@ -5,11 +5,12 @@ The [Lagoon PostgreSQL Docker image](https://github.com/uselagoon/lagoon-images/
 ## Supported versions
 
 * 11 \(available for compatibility only, no longer officially supported\) - `uselagoon/postgres-11`
-* 12 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/postgres/12.Dockerfile) (Security Support until November 2024) - `uselagoon/postgres-12`
+* 12 \(available for compatibility only, no longer officially supported\) - `uselagoon/postgres-12`
 * 13 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/postgres/13.Dockerfile) (Security Support until November 2025) - `uselagoon/postgres-13`
 * 14 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/postgres/14.Dockerfile) (Security Support until November 2026) - `uselagoon/postgres-14`
 * 15 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/postgres/15.Dockerfile) (Security Support until November 2027) - `uselagoon/postgres-15`
 * 16 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/postgres/16.Dockerfile) (Security Support until November 2028) - `uselagoon/postgres-16`
+* 17 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/postgres/17.Dockerfile) (Security Support until November 2029) - `uselagoon/postgres-17`
 
 !!! Tip
     We stop updating EOL PostgreSQL images usually with the Lagoon release that comes after the officially communicated EOL date: [https://www.postgresql.org/support/versioning](https://www.postgresql.org/support/versioning/)

--- a/docs/docker-images/python.md
+++ b/docs/docker-images/python.md
@@ -6,11 +6,12 @@ The [Lagoon `python` Docker image](https://github.com/uselagoon/lagoon-images/tr
 
 * 2.7 \(available for compatibility only, no longer officially supported\) - `uselagoon/python-2.7`
 * 3.7 \(available for compatibility only, no longer officially supported\) - `uselagoon/python-3.7`
-* 3.8 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/python/3.8.Dockerfile) (Security Support until October 2024) - `uselagoon/python-3.8`
+* 3.8 \(available for compatibility only, no longer officially supported\) - `uselagoon/python-3.8`
 * 3.9 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/python/3.9.Dockerfile) (Security Support until October 2025) - `uselagoon/python-3.9`
 * 3.10 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/python/3.10.Dockerfile) (Security Support until October 2026) - `uselagoon/python-3.10`
 * 3.11 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/python/3.11.Dockerfile) (Security Support until October 2027) - `uselagoon/python-3.11`
 * 3.12 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/python/3.12.Dockerfile) (Security Support until October 2028) - `uselagoon/python-3.12`
+* 3.13 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/python/3.13.Dockerfile) (Security Support until October 2029) - `uselagoon/python-3.13`
 
 !!! Tip
     We stop updating and publishing EOL Python images usually with the Lagoon release that comes after the officially communicated EOL date: [https://devguide.python.org/versions/#versions](https://devguide.python.org/versions/#versions). Previous published versions will remain available.

--- a/docs/docker-images/redis.md
+++ b/docs/docker-images/redis.md
@@ -11,6 +11,9 @@ This Dockerfile is intended to be used to set up a standalone Redis _ephemeral_ 
 * 7 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/redis/7.Dockerfile) - `uselagoon/redis-7` or `uselagoon/redis-7-persistent`
 * 8 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/redis/8.Dockerfile) - `uselagoon/redis-8`
 
+!!! Tip
+    We stop updating and publishing EOL Redis images usually with the Lagoon release that comes after the officially communicated EOL date: [https://redis.io/docs/latest/operate/rs/installing-upgrading/product-lifecycle/](https://redis.io/docs/latest/operate/rs/installing-upgrading/product-lifecycle/). Previous published versions will remain available.
+
 ## Usage
 
 There are 2 different flavors of Redis: **Ephemeral** and **Persistent**.

--- a/docs/docker-images/redis.md
+++ b/docs/docker-images/redis.md
@@ -9,20 +9,21 @@ This Dockerfile is intended to be used to set up a standalone Redis _ephemeral_ 
 * 5 \(available for compatibility only, no longer officially supported\) - `uselagoon/redis-5` or `uselagoon/redis-5-persistent`
 * 6 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/redis/6.Dockerfile) - `uselagoon/redis-6` or `uselagoon/redis-6-persistent`
 * 7 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/redis/7.Dockerfile) - `uselagoon/redis-7` or `uselagoon/redis-7-persistent`
+* 8 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/redis/8.Dockerfile) - `uselagoon/redis-8`
 
 ## Usage
 
-There are 2 different flavors of Redis Images: **Ephemeral** and **Persistent**.
+There are 2 different flavors of Redis: **Ephemeral** and **Persistent**.
 
 ### Ephemeral
 
-The ephemeral image is intended to be used as an in-memory cache for applications and will not retain data across container restarts.
+The ephemeral flavor is intended to be used as an in-memory cache for applications and will not retain data across container restarts.
 
 When being used as an in-memory (RAM) cache, the first thing you might want to tune if you have large caches is to adapt the `MAXMEMORY` variable. This variable controls the maximum amount of memory (RAM) which redis will use to store cached items.
 
 ### Persistent
 
-The persistent Redis image will persist data across container restarts and can be used for queues or application data that will need persistence.
+The persistent Redis flavor will persist data across container restarts and can be used for queues or application data that will need persistence.
 
 We don't typically suggest using a persistent Redis for in-memory cache scenarios as this might have unintended side-effects on your application while a Redis container is restarting and loading data from disk.
 
@@ -48,6 +49,7 @@ variables](../concepts-advanced/environment-variables.md).
 | LOGLEVEL             | notice      | Define the level of logs.                                                                  |
 | MAXMEMORY            | 100mb       | Maximum amount of memory.                                                                  |
 | MAXMEMORYPOLICY      | allkeys-lru | The policy to use when evicting keys if Redis reaches its maximum memory usage.            |
+| REDIS_FLAVOR         | ephemeral   | The Redis configuration flavor to load. Can be `ephemeral` or `persistent`. |
 | REDIS_PASSWORD       | disabled    | Enables [authentication feature](https://redis.io/topics/security#authentication-feature). |
 
 ## Custom configuration
@@ -55,11 +57,17 @@ variables](../concepts-advanced/environment-variables.md).
 By building on the base image you can include custom configuration.
 See [https://github.com/redis/redis/blob/7.2.5/redis.conf](https://github.com/redis/redis/blob/7.2.5/redis.conf) for full documentation of the Redis configuration file.
 
-## Redis-persistent
+## Persistent storage
 
-Based on the [Lagoon `redis` image](https://github.com/uselagoon/lagoon-images/blob/main/images/redis/6.Dockerfile), the [Lagoon `redis-persistent` Docker image](https://github.com/uselagoon/lagoon-images/blob/main/images/redis-persistent/6.Dockerfile) is intended for use when the Redis service must be utilized in `persistent` mode \(ie. with a persistent volume where keys will be saved to disk\).
+### Redis <= 7
+
+The [Lagoon `redis-persistent` Docker image](https://github.com/uselagoon/lagoon-images/blob/main/images/redis-persistent/6.Dockerfile) is intended for use when the Redis service must be utilized in `persistent` mode \(ie. with a persistent volume where keys will be saved to disk\). It is based on the [Lagoon `redis` image](https://github.com/uselagoon/lagoon-images/blob/main/images/redis/6.Dockerfile).
 
 It differs from `redis` only with the `FLAVOR` environment variable, which will use the [respective Redis configuration](https://github.com/uselagoon/lagoon-images/tree/main/images/redis/conf) according to the version of redis in use.
+
+### Redis >= 8
+
+The [Lagoon `redis` image](https://github.com/uselagoon/lagoon-images/blob/main/images/redis/6.Dockerfile) will check which flavor of Redis to use by inspecting the `REDIS_FLAVOR` env var. When set to `persistent`, the persistent configuration will be loaded.
 
 ## Troubleshooting
 
@@ -71,7 +79,7 @@ By default, the Lagoon `redis` images are set to use the `allkeys-lru` policy. T
 
 For typical installations, this is the ideal configuration, as Drupal may not set a `TTL` value for each key cached in Redis. If the `maxmemory-policy` is set to something like `volatile-lru` and Drupal doesn't provide these `TTL` tags, this would result in the Redis container filling up, being totally unable to evict **ANY** keys, and ceasing to accept new cache keys at all.
 
-More information on Redis' maxmemory policies can be found in Redis' [official documentation](https://redis.io/docs/manual/eviction/#eviction-policies).
+More information on Redis' maxmemory policies can be found in Redis' [official documentation](https://redis.io/docs/latest/operate/rs/databases/memory-performance/eviction-policy/).
 
 !!! danger "Proceed with Caution"
     Changing this setting can lead to Redis becoming completely full and cause outages as a result.

--- a/docs/docker-images/ruby.md
+++ b/docs/docker-images/ruby.md
@@ -5,10 +5,10 @@ The [Lagoon `ruby` Docker image](https://github.com/uselagoon/lagoon-images/tree
 ## Supported Versions
 
 * 3.0 \(available for compatibility only, no longer officially supported\) - `uselagoon/ruby-3.0`
-* 3.1 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/ruby/3.1.Dockerfile) (Security Support until March 2025) - `uselagoon/ruby-3.1`
+* 3.1 \(available for compatibility only, no longer officially supported\) - `uselagoon/ruby-3.1`
 * 3.2 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/ruby/3.2.Dockerfile) (Security Support until March 2026) - `uselagoon/ruby-3.2`
 * 3.3 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/ruby/3.3.Dockerfile) (Security Support until March 2027) - `uselagoon/ruby-3.3`
-
+* 3.4 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/ruby/3.4.Dockerfile) (Security Support until March 2028) - `uselagoon/ruby-3.4`
 
 !!! Tip
     We stop updating and publishing EOL Ruby images usually with the Lagoon release that comes after the officially communicated EOL date: [https://www.ruby-lang.org/en/downloads/releases/](https://www.ruby-lang.org/en/downloads/releases/). Previous versions will remain available.

--- a/docs/docker-images/solr.md
+++ b/docs/docker-images/solr.md
@@ -13,6 +13,9 @@ This Dockerfile is intended to be used to set up a standalone Solr server with a
 * 8 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/solr/8.Dockerfile) - `uselagoon/solr-8`
 * 9 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/solr/9.Dockerfile) - `uselagoon/solr-9`
 
+!!! Tip
+    We stop updating and publishing EOL Solr images usually with the Lagoon release that comes after the officially communicated EOL date: [https://solr.apache.org/downloads.html](https://solr.apache.org/downloads.html). Previous versions will remain available.
+
 ## Lagoon adaptions
 
 This image is prepared to be used on Lagoon. There are therefore some things already done:

--- a/docs/docker-images/valkey.md
+++ b/docs/docker-images/valkey.md
@@ -1,0 +1,105 @@
+# Valkey
+
+[Lagoon `valkey` image Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/valkey), based on [official `valkey/valkey:alpine` image](https://hub.docker.com/r/valkey/valkey).
+
+This Dockerfile is intended to be used to set up a standalone Valkey _ephemeral_ server by default.
+
+!!! info
+    Valkey is a [community-led successor to Redis](https://www.linuxfoundation.org/press/linux-foundation-launches-open-source-valkey-community) It's intended to be backwards compatible, but any integration should always be tested prior to first use.
+
+## Supported versions
+
+* 8 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/valkey/8.Dockerfile) - `uselagoon/valkey-8`
+
+## Usage
+
+There are 2 different flavors of Valkey: **Ephemeral** and **Persistent**.
+
+### Ephemeral
+
+The ephemeral flavor is intended to be used as an in-memory cache for applications and will not retain data across container restarts.
+
+When being used as an in-memory (RAM) cache, the first thing you might want to tune if you have large caches is to adapt the `MAXMEMORY` variable. This variable controls the maximum amount of memory (RAM) which valkey will use to store cached items.
+
+### Persistent
+
+The persistent Valkey flavor will persist data across container restarts and can be used for queues or application data that will need persistence.
+
+We don't typically suggest using a persistent Valkey for in-memory cache scenarios as this might have unintended side-effects on your application while a Valkey container is restarting and loading data from disk.
+
+## Lagoon adaptions
+
+This image is prepared to be used on Lagoon. There are therefore some things already done:
+
+* Folder permissions are automatically adapted with [`fix-permissions`](https://github.com/uselagoon/lagoon-images/blob/main/images/commons/fix-permissions)so this image will work with a random user.
+* The files within `/etc/valkey/*` are templated using [`envplate`](https://github.com/kreuzwerker/envplate) via a container-entrypoint.
+
+## Included `valkey.conf` configuration file
+
+The image ships a _default_ Valkey configuration file, optimized to work on Lagoon.
+
+### Environment Variables
+
+Some options are configurable via [environment
+variables](../concepts-advanced/environment-variables.md).
+
+| Environment Variable | Default     |                                        Description                                         |
+| :------------------- | :---------- | :----------------------------------------------------------------------------------------- |
+| DATABASES            | -1          | Default number of databases created at startup.                                            |
+| LOGLEVEL             | notice      | Define the level of logs.                                                                  |
+| MAXMEMORY            | 100mb       | Maximum amount of memory.                                                                  |
+| MAXMEMORYPOLICY      | allkeys-lru | The policy to use when evicting keys if Valkey reaches its maximum memory usage.            |
+| VALKEY_FLAVOR        | ephemeral   | The Valkey configuration flavor to load. Can be `ephemeral` or `persistent`. |
+| VALKEY_PASSWORD      | disabled    | Enables [authentication feature](https://valkey.io/topics/security#authentication-feature). |
+
+## Custom configuration
+
+By building on the base image you can include custom configuration.
+See [https://github.com/valkey-io/valkey/blob/8.1/valkey.conf](https://github.com/valkey-io/valkey/blob/8.1/valkey.conf) for full documentation of the Valkey configuration file.
+
+## Persistent storage
+
+The [Lagoon `valkey` image](https://github.com/uselagoon/lagoon-images/blob/main/images/valkey/6.Dockerfile) will check which flavor of Valkey to use by inspecting the `VALKEY_FLAVOR` env var. When set to `persistent`, the persistent configuration will be loaded.
+
+## Troubleshooting
+
+The Lagoon Valkey images all come pre-loaded with the `valkey-cli` command, which allows for querying the Valkey service for information and setting config values dynamically. To use this utility, you can simply SSH into your Valkey pod by using the instructions [here](../interacting/ssh.md) with `valkey` as the `pod` value then run it from the terminal once you've connected.
+
+### Maximum Memory Policy
+
+By default, the Lagoon `valkey` images are set to use the `allkeys-lru` policy. This policy will alow **ANY** keys stored in Valkey to be evicted if/when the Valkey service hits its `maxmemory` limit according to when the key was least recently used.
+
+For typical installations, this is the ideal configuration, as Drupal may not set a `TTL` value for each key cached in Valkey. If the `maxmemory-policy` is set to something like `volatile-lru` and Drupal doesn't provide these `TTL` tags, this would result in the Valkey container filling up, being totally unable to evict **ANY** keys, and ceasing to accept new cache keys at all.
+
+More information on Valkey' maxmemory policies can be found in Valkey' [official documentation](https://valkey.io/topics/lru-cache/#eviction-policies).
+
+!!! danger "Proceed with Caution"
+    Changing this setting can lead to Valkey becoming completely full and cause outages as a result.
+
+### Tuning Valkey' `maxmemory` value
+
+Finding the optimal amount of memory to give Valkey can be quite the difficult task. Before attempting to tune your Valkey cache's memory size, it is prudent to let it run normally for as long as practical, with at least a day of typical usage being the ideal minimum timeframe.
+
+There are a few high level things you can look at when tuning these memory values:
+
+* The first thing to check is the percentage of memory in use by Valkey currently.
+  * If this percentage is less than `50%`, you might consider lowering the `maxmemory` value by 25%.
+  * If this percentage is between `50%` and `75%`, things are running just fine.
+  * If this value is greater than `75%`, then it's worth looking at other variables to see if `maxmemory` needs to be increased.
+* If you find that your Valkey' memory usage percentage is high, the next thing to look at is the number of key evictions.
+  * A large number of key evictions and a memory usage greater than `95%` is a fairly good indicator that your valkey needs a higher `maxmemory` setting.
+  * If the number of key evictions doesn't seem high and typical response times are reasonable, this is simply indicative of Valkey doing its job and managing its allocated memory as expected.
+
+### Example commands
+
+The following commands can be used to view information about the Valkey service:
+
+* View all info about the Valkey service: `valkey-cli info`
+* View service memory information: `valkey-cli info memory`
+* View service keyspace information: `valkey-cli info keyspace`
+* View service statistics: `valkey-cli info stats`
+
+It is also possible to set values for the Valkey service dynamically without a restart of the Valkey service. It is important to note that these dynamically set values will not persist if the pod is restarted (which can happen as a result of a deployment, maintenance, or even just being shuffled from one node to another).
+
+* Set `maxmemory` config value dynamically to `500mb`: `config set maxmemory 500mb`
+* Set `maxmemory-policy` config value dynamically to `volatile-lru`: `config set maxmemory-policy volatile-lru`

--- a/docs/resources/glossary.md
+++ b/docs/resources/glossary.md
@@ -109,6 +109,7 @@ description: >-
 | TLS | Transport Layer Security |
 | Trivy | A simple and comprehensive vulnerability scanner for containers, suitable for CI. |
 | TTL | Time to live or hop limit is a mechanism that limits the lifespan or lifetime of data in a computer or network. |
+| Valkey | An open source, community-led successor to Redis. |
 | Varnish | A powerful, open-source HTTP engine/reverse HTTP proxy that can speed up a website by caching \(or storing\) a copy of a webpage the first time a user visits. |
 | VM | Virtual Machine |
 | Webhook | A webhook is a way for an app like GitHub, GitLab, Bitbucket, etc, to provide other applications with immediate data and act upon something, like a pull request. |

--- a/docs/using-lagoon-the-basics/index.md
+++ b/docs/using-lagoon-the-basics/index.md
@@ -45,20 +45,22 @@ Some Docker images and containers need additional customizations from the provid
 
 | Type | Versions | Dockerfile |
 | :--- | :--- | :--- |
-| [MariaDB](../docker-images/mariadb.md) | 10.4, 10.5, 10.6, 10.11 | [mariadb/Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/mariadb) |
-| [PostgreSQL](../docker-images/postgres.md) | 11, 12, 13, 14, 15, 16 | [postgres/Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/postgres) |
+| [MariaDB](../docker-images/mariadb.md) | 10.6, 10.11, 11.4 | [mariadb/Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/mariadb) |
 | [MongoDB](../docker-images/mongodb.md) | 4 | [mongo/Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/mongo) |
+| [MySQL](../docker-images/mysql.md) | 8.0, 8.4 | [mysql/Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/mysql) |
 | [NGINX](../docker-images/nginx.md) | openresty/1.25 | [nginx/Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/nginx) |
 | [Node.js](../docker-images/nodejs.md) | 18, 20, 22 | [node/Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/node) |
-| [PHP FPM](../docker-images/php-fpm.md) | 8.1, 8.2, 8.3 | [php/fpm/Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/php-fpm) |
-| [PHP CLI](../docker-images/php-cli.md) | 8.1, 8.2, 8.3 | [php/cli/Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/php-cli) |
-| [Python](../docker-images/nodejs.md) | 3.8, 3.9, 3.10, 3.11, 3.12 | [python/Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/python) |
-| [Redis](../docker-images/redis.md) | 6, 7 | [redis/Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/redis) |
-| [Solr](../docker-images/solr.md) | 8, 9 | [solr/Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/solr) |
-| [Varnish](../docker-images/varnish.md) | 6, 7 | [varnish/Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/varnish) |
-| [Opensearch](../docker-images/opensearch.md) | 2 | [opensearch/Dockerfiles](https://github.com/uselagoon/lagoon-images/blob/main/images/opensearch) |
+| [OpenSearch](../docker-images/opensearch.md) | 2, 3 | [opensearch/Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/opensearch) |
+| [PHP CLI](../docker-images/php-cli.md) | 8.1, 8.2, 8.3, 8.4 | [php/cli/Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/php-cli) |
+| [PHP FPM](../docker-images/php-fpm.md) | 8.1, 8.2, 8.3, 8.4 | [php/fpm/Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/php-fpm) |
+| [PostgreSQL](../docker-images/postgres.md) | 13, 14, 15, 16, 17 | [postgres/Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/postgres) |
+| [Python](../docker-images/nodejs.md) | 3.9, 3.10, 3.11, 3.12, 3.13 | [python/Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/python) |
 | [RabbitMQ](../docker-images/rabbitmq.md) | 3.10 | [rabbitmq/Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/rabbitmq) |
-| [Ruby](../docker-images/ruby.md) | 3.1, 3.2, 3.3 | [ruby/Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/ruby) |
+| [Redis](../docker-images/redis.md) | 6, 7, 8 | [redis/Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/redis) |
+| [Ruby](../docker-images/ruby.md) | 3.2, 3.3, 3.4 | [ruby/Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/ruby) |
+| [Solr](../docker-images/solr.md) | 8, 9 | [solr/Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/solr) |
+| [Valkey](../docker-images/valkey.md) | 8 | [valkey/Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/valkey) |
+| [Varnish](../docker-images/varnish.md) | 6, 7 | [varnish/Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/varnish) |
 
 All images are pushed to [https://hub.docker.com/u/uselagoon](https://hub.docker.com/u/uselagoon). We suggest always using the latest tag \(like `uselagoon/nginx:latest`\) as they are kept up to date in terms of features and security.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
       - Ruby: docker-images/ruby.md
       - Solr: docker-images/solr.md
       - Redis: docker-images/redis.md
+      - Valkey: docker-images/valkey.md
       - Varnish: docker-images/varnish.md
       - Deprecated Images: docker-images/deprecated-images.md
     - Configuring Applications:


### PR DESCRIPTION
# Description

* Updates docs for the Redis 8 image and how it differs from redis <= 7.
* Adds a page for the Valkey image.

**Note:** Redis 8 images haven't been released yet, so this could wait a bit before merging.