### PR TITLE
fix: uploading/deleting task files succeeds but returns api error

### DIFF
--- a/services/api/src/loggers/lagoonLogsTransport.ts
+++ b/services/api/src/loggers/lagoonLogsTransport.ts
@@ -44,7 +44,7 @@ export class LagoonLogsTransport extends Transport {
       // saving internal tokens to the event log would result in massive amounts of logged data
       // ideally LEGACY_EXPIRY_MAX and LEGACY_EXPIRY_REJECT are tuned to ensure use of legacy tokens is useless outside
       // of internal systems
-      if (info.event && info.event != "api:unknownEvent" && info.payload.resource && info.user.access_token) {
+      if (info.event && info.event != "api:unknownEvent" && info.payload?.resource && info.user?.access_token) {
         // try and determine the user request from headers, fall back to api
         const requestSource = info.headers['referer'] ? AuditSourceType.UI : info.headers['user-agent'].includes("lagoon-client") ? AuditSourceType.CLI : AuditSourceType.API
         const aLog = {

--- a/services/api/src/resources/file/resolvers.ts
+++ b/services/api/src/resources/file/resolvers.ts
@@ -53,9 +53,10 @@ export const uploadFilesForTask: ResolverFn = async (
     sqlClientPool,
     taskSql.selectPermsForTask(task)
   );
+  const projectId = R.path(['0', 'pid'], rowsPerms);
 
   await hasPermission('task', 'update', {
-    project: R.path(['0', 'pid'], rowsPerms)
+    project: projectId
   });
 
   const resolvedFiles = await Promise.all(files);
@@ -90,22 +91,19 @@ export const uploadFilesForTask: ResolverFn = async (
   await Promise.all(uploadAndTrackFiles);
 
   const rows = await query(sqlClientPool, taskSql.selectTask(task));
+  task = R.prop(0, rows);
 
-  userActivityLogger(`User uploaded files for task '${task}' on project
-      '${R.path(
-      ['0', 'pid'],
-      rowsPerms
-    )}'`,
+  userActivityLogger(`User uploaded files for task '${task.id}' on project '${projectId}'`,
     {
       project: '',
       event: 'api:uploadFilesForTask',
-      data: {
-        rows
+      payload: {
+        task
       }
     }
   );
 
-  return R.prop(0, rows);
+  return task;
 };
 
 export const deleteFilesForTask: ResolverFn = async (
@@ -136,7 +134,7 @@ export const deleteFilesForTask: ResolverFn = async (
   userActivityLogger(`User deleted files for task '${id}'`, {
     project: '',
     event: 'api:deleteFilesForTask',
-    data: {
+    payload: {
       id
     }
   });


### PR DESCRIPTION
Cannot read properties of undefined (reading 'resource')

 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Database Migrations

n/a

# Description

The object passed to `userActivityLogger` for task file resolvers didn't match what was expected in the audit logging logic which caused the resolvers to return error even though they succeeded. This fixes the expected structure and makes the audit logic more permissive.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

n/a
