### PR TITLE
fix: update task audit log

### DIFF
--- a/services/api/src/resources/task/resolvers.ts
+++ b/services/api/src/resources/task/resolvers.ts
@@ -466,6 +466,11 @@ export const updateTask: ResolverFn = async (
     project: R.path(['0', 'pid'], curPerms)
   });
 
+  const task = await query(sqlClientPool, Sql.selectTask(id));
+  const env = await environmentHelpers(sqlClientPool).getEnvironmentById(
+    task[0].environment
+  );
+
   if (environment) {
     // Check access to modify task as it will be updated
     const envPerm = await environmentHelpers(sqlClientPool).getEnvironmentById(
@@ -506,9 +511,9 @@ export const updateTask: ResolverFn = async (
 
   const auditLog: AuditLog = {
     resource: {
-      id: environment.id,
+      id: env.id,
       type: AuditType.ENVIRONMENT,
-      details: environment.name,
+      details: env.name,
     },
     linkedResource: {
       id: taskData.id,


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

While reviewing #3938 I noticed in the logs that the updateTask resolver was also reporting an error. This adjusts the resolver to do the permission check properly with the environment id of the task, while collecting the information required for the audit log to correctly associate the information to the log as required.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

