### PR TITLE
fix: add typename to field check to resolve permission error

### DIFF
--- a/services/api/src/resources/organization/resolvers.ts
+++ b/services/api/src/resources/organization/resolvers.ts
@@ -371,8 +371,7 @@ export const getOrganizationByProject: ResolverFn = async (
     return null
   }
 
-  const extraFields = requestsExtraFields(info, ['id', 'name', 'friendlyName']);
-
+  const extraFields = requestsExtraFields(info, ['__typename', 'id', 'name', 'friendlyName']);
   if (extraFields) {
     await hasPermission('organization', 'view', {
       organization: project.organization,


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

Fixes an issue with the extra field check to include `__typename` in the included fields to fix permission error for non-organization owners

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

This can be verified in a `k3d/local-stack` using the `orguser` account to view the project overview page. With this patch in place the page loads, without there is a permission denied error.
