### PR TITLE
docs: `uselagoon/redis-6` is deprecated

### DIFF
--- a/docs/docker-images/redis.md
+++ b/docs/docker-images/redis.md
@@ -6,8 +6,8 @@ This Dockerfile is intended to be used to set up a standalone Redis _ephemeral_ 
 
 ## Supported versions
 
-* 5 \(available for compatibility only, no longer officially supported\) - `uselagoon/redis-5` or `uselagoon/redis-5-persistent`
-* 6 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/redis/6.Dockerfile) - `uselagoon/redis-6` or `uselagoon/redis-6-persistent`
+* 5 (available for compatibility only, no longer officially supported) - `uselagoon/redis-5` or `uselagoon/redis-5-persistent`
+* 6 (available for compatibility only, no longer officially supported) - `uselagoon/redis-6` or `uselagoon/redis-6-persistent`
 * 7 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/redis/7.Dockerfile) - `uselagoon/redis-7` or `uselagoon/redis-7-persistent`
 * 8 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/redis/8.Dockerfile) - `uselagoon/redis-8`
 
@@ -64,7 +64,7 @@ See [https://github.com/redis/redis/blob/7.2.5/redis.conf](https://github.com/re
 
 ### Redis <= 7
 
-The [Lagoon `redis-persistent` Docker image](https://github.com/uselagoon/lagoon-images/blob/main/images/redis-persistent/6.Dockerfile) is intended for use when the Redis service must be utilized in `persistent` mode \(ie. with a persistent volume where keys will be saved to disk\). It is based on the [Lagoon `redis` image](https://github.com/uselagoon/lagoon-images/blob/main/images/redis/6.Dockerfile).
+The [Lagoon `redis-persistent` Docker image](https://github.com/uselagoon/lagoon-images/blob/main/images/redis-persistent/6.Dockerfile) is intended for use when the Redis service must be utilized in `persistent` mode (ie. with a persistent volume where keys will be saved to disk). It is based on the [Lagoon `redis` image](https://github.com/uselagoon/lagoon-images/blob/main/images/redis/6.Dockerfile).
 
 It differs from `redis` only with the `FLAVOR` environment variable, which will use the [respective Redis configuration](https://github.com/uselagoon/lagoon-images/tree/main/images/redis/conf) according to the version of redis in use.
 

--- a/docs/ja/docker-images/redis.md
+++ b/docs/ja/docker-images/redis.md
@@ -6,8 +6,8 @@
 
 ## サポートされているバージョン { #supported-versions }
 
-* 5 \(互換性のためのみ利用可能、公式サポートは終了しています\) - `uselagoon/redis-5`または`uselagoon/redis-5-persistent`
-* 6 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/redis/6.Dockerfile) - `uselagoon/redis-6`または`uselagoon/redis-6-persistent`
+* 5 (互換性のためのみ利用可能、公式サポートは終了しています) - `uselagoon/redis-5`または`uselagoon/redis-5-persistent`
+* 6 (互換性のためのみ利用可能、公式サポートは終了しています) - `uselagoon/redis-6`または`uselagoon/redis-6-persistent`
 * 7 [Dockerfile](https://github.com/uselagoon/lagoon-images/blob/main/images/redis/7.Dockerfile) - `uselagoon/redis-7`または`uselagoon/redis-7-persistent`
 
 ## 使用方法


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Database Migrations

n/a

# Description

Updating docs to reflect the fact that redis 6 is deprecated and we are no longer publishing images