### PR TITLE
docs: update local-stack backups

### DIFF
--- a/docs/contributing-to-lagoon/developing-lagoon.md
+++ b/docs/contributing-to-lagoon/developing-lagoon.md
@@ -230,14 +230,14 @@ Currently, Harbor does not have any arm64 based images. This means local-stack w
 
 If you want to skip installing Harbor entirely, even if your system is not arm based, you can use the following
 
-```bash title="Harbor disabled
+```bash title="Harbor disabled"
 INSTALL_UNAUTHENTICATED_REGISTRY=true
 ```
 
 !!! info
     There are [open issues](https://github.com/goharbor/harbor/issues/20074) in the harbor repository with people requesting support for arm, and even a [harbor-arm repository](https://github.com/goharbor/harbor-arm), which appears to be abandoned.
 
-#### Backups / K8up
+#### Backups with K8up
 
 It is possible to start the local-stack with k8up support for `backup.appuio.ch/v1alpha`(v1) and `k8up.io/v1`(v2) for testing and validating that backups work, or verifying changes to backup functionality.
 
@@ -245,14 +245,15 @@ There are 2 make variables you can set, by default k8up is not installed.
 
 If you wish to install k8up, you can change the following in the Makefile (or use it on every make command you run). This will install both versions of k8up into the local-stack in separate namespaces. The version that `lagoon-remote` will use is defined with a separate variable
 
-```bash title="K8up enabled
-INSTALL_K8UP=true
+```bash title="K8up enabled"
+make k3d/local-stack INSTALL_K8UP=true
 ```
 
 If k8up is installed, the default version that will be supported by `lagoon-remote` will be `k8up.io/v1`(v2) of k8up. This means any builds will create resources with this CRD version. You can change the version that `lagoon-remote` uses by specifying `v1` or `v2`.
+For example, to install v1:
 
-```bash title="K8up version
-BUILD_DEPLOY_CONTROLLER_K8UP_VERSION=v2
+```bash title="K8up version"
+make k3d/local-stack INSTALL_K8UP=true REMOTE_CONTROLLER_K8UP_VERSION=v1
 ```
 
 Installing k8up will also configure `lagoon-core` to start the `backup-handler` service so that the entire system works locally.


### PR DESCRIPTION
# General Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Description

Fixes some code snippet display issues in the k8up section of the local-stack docs, as well as some other minor updates.