### PR TITLE
fix: local-dev/jwt version check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -617,11 +617,11 @@ endif
 
 .PHONY: local-dev/jwt
 local-dev/jwt:
-ifeq ($(JWT_VERSION), $(shell jwt -v 2>/dev/null | sed -nE 's/jwt ([0-9.]+).*/v\1/p'))
+ifeq ($(JWT_VERSION), $(shell jwt --version 2>/dev/null | sed -nE 's/jwt ([0-9.]+).*/\1/p'))
 	$(info linking local jwt version $(JWT_VERSION))
 	ln -sf $(shell command -v jwt) ./local-dev/jwt
 else
-ifneq ($(JWT_VERSION), $(shell ./local-dev/jwt -v 2>/dev/null | sed -nE 's/jwt ([0-9.]+).*/v\1/p'))
+ifneq ($(JWT_VERSION), $(shell ./local-dev/jwt --version 2>/dev/null | sed -nE 's/jwt ([0-9.]+).*/\1/p'))
 	$(info downloading jwt version $(JWT_VERSION) for $(ARCH))
 	rm -f local-dev/jwt || true
 ifeq ($(ARCH), darwin)


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

This fixes a small version check error in the `local-dev/jwt` target to prevent downloading it every time.
