### PR TITLE
docs: remove deprecated `hsts` examples

### DIFF
--- a/docs/ja/lagoonizing/index.md
+++ b/docs/ja/lagoonizing/index.md
@@ -257,7 +257,6 @@ environments:
         - "www.example.com":
             tls-acme: 'true'
             insecure: Redirect
-            hsts: max-age=31536000
         - "example.ch":
             Annotations:
               nginx.ingress.kubernetes.io/permanent-redirect: https://www.example.ch$request_uri
@@ -406,12 +405,6 @@ UptimeRobotがクラスタに設定されている場合、Lagoonは各ルート
 `None`
 
 - HTTPのルートは作成されず、リダイレクトも行われません。
-
-`Hsts`
-
-- `max-age=31536000;includeSubDomains;preload`のような値を設定できます。
-- スペースや他のパラメータが含まれていないことを確認します。
-- `max-age`パラメータのみが必須です。これはHSTSポリシーの有効期間を秒単位で指定します。
 
 !!! Info "Info"
     証明書認証局(CA)によって署名された SSL 証明書から Let's Encrypt 証明書に切り替える予定がある場合は、Lagoon の管理者に連絡して移行を監督してもらうのが最善です。

--- a/docs/lagoonizing/index.md
+++ b/docs/lagoonizing/index.md
@@ -259,7 +259,6 @@ environments:
         - "www.example.com":
             tls-acme: 'true'
             insecure: Redirect
-            hsts: max-age=31536000
         - "example.ch":
             Annotations:
               nginx.ingress.kubernetes.io/permanent-redirect: https://www.example.ch$request_uri
@@ -399,12 +398,6 @@ You can of course also redirect to any other URL not hosted on Lagoon. This will
 `None`
 
 - Will mean a route for HTTP will not be created, and no redirect will take place.
-
-`Hsts`
-
-- Can be set to a value of `max-age=31536000;includeSubDomains;preload`.
-- Ensure there are no spaces and no other parameters included.
-- Only the `max-age` parameter is required. The required max-age parameter indicates the length of time, in seconds, the HSTS policy is in effect for.
 
 !!! info
     If you plan to switch from a SSL certificate signed by a Certificate Authority (CA) to a Let's Encrypt certificate, it's best to get in touch with {{ defaults.helpstring }} to oversee the transition.


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Description

Our lagoonizing docs still showed examples of configuring `HSTS` using a deprecated method.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues
n/a