### PR TITLE
refactor: use mkcert root CA if available for `k3d/local-stack`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -791,7 +791,7 @@ k3d/checkout-charts: k3d/generate-ca
 		&& cd "$$CHARTSDIR" \
 		&& git checkout $(CHARTS_TREEISH) \
 		&& mkdir -p certs \
-		&& cp ../local-dev/certificates/* certs/.
+		&& test -f $$(mkcert -CAROOT)/rootCA.pem && cp $$(mkcert -CAROOT)/* certs/. || cp ../local-dev/certificates/* certs/.
 
 
 # this just installs lagoon-core, lagoon-remote, and lagoon-build-deploy
@@ -1133,8 +1133,12 @@ k3d/regenerate-ca:
 .PHONY: install-ca
 install-ca:
 ifeq ($(shell command -v mkcert > /dev/null && echo 1 || echo 0), 1)
-	@export CAROOT=local-dev/certificates && \
-	mkcert -install
+	@if test -f "$$(mkcert -CAROOT)/rootCA.pem"; then \
+		echo "Using mkcert root CA in $$(mkcert -CAROOT)"; \
+	else \
+		export CAROOT=local-dev/certificates && \
+		mkcert -install; \
+	fi
 else
 	@echo "mkcert not installed, please install mkcert. See https://github.com/FiloSottile/mkcert#installation"
 endif


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Database Migrations

n/a

# Description

Changes `k3d/local-stack` to use `mkcert` root certificates instead of generated ones if available. This makes it so that multiple lagoon repos on the same machine don't install multiple certs.

# Closing issues

n/a