### PR TITLE
feat: environment storage filtering support

### DIFF
--- a/services/api/src/resources/environment/resolvers.ts
+++ b/services/api/src/resources/environment/resolvers.ts
@@ -169,11 +169,11 @@ export const getEnvironmentStorageByEnvironmentId: ResolverFn = async (
   { sqlClientPool, hasPermission, adminScopes }
 ) => {
   if (args) {
-    // set limit to args.limit, or 60 if undefined
-    let limit = args.limit || 60;
+    // set lastDays to args.lastDays, or 60 if undefined
+    let lastDays = args.lastDays || 60;
     if (!adminScopes.platformOwner && !adminScopes.platformViewer) {
-      // limit to 60 results for non-platform users
-      limit = Math.min(args.limit || 60, 60);
+      // lastDays to 60 results for non-platform users
+      lastDays = Math.min(args.lastDays || 60, 60);
 
       // check permissions for non-platform users
       const project = await projectHelpers(
@@ -183,7 +183,7 @@ export const getEnvironmentStorageByEnvironmentId: ResolverFn = async (
         project: project.id
       });
     }
-    const rows = await query(sqlClientPool, Sql.selectEnvironmentStorageByEnvironmentIdByDaysClaim({eid, limit, claim: args.claim, startDate: args.startDate, endDate: args.endDate}))
+    const rows = await query(sqlClientPool, Sql.selectEnvironmentStorageByEnvironmentIdByDaysClaim({eid, lastDays, claim: args.claim, startDate: args.startDate, endDate: args.endDate}))
     // @DEPRECATE when `bytesUsed` is completely removed, this can be reverted
     return rows.map(row => ({ ...row, bytesUsed: row.kibUsed}));
   }

--- a/services/api/src/resources/environment/resolvers.ts
+++ b/services/api/src/resources/environment/resolvers.ts
@@ -166,8 +166,28 @@ export const getEnvironmentByBackupId: ResolverFn = async (
 export const getEnvironmentStorageByEnvironmentId: ResolverFn = async (
   { id: eid },
   args,
-  { sqlClientPool, hasPermission }
+  { sqlClientPool, hasPermission, adminScopes }
 ) => {
+  if (args) {
+    // set limit to args.limit, or 60 if undefined
+    let limit = args.limit || 60;
+    if (!adminScopes.platformOwner && !adminScopes.platformViewer) {
+      // limit to 60 results for non-platform users
+      limit = Math.min(args.limit || 60, 60);
+
+      // check permissions for non-platform users
+      const project = await projectHelpers(
+        sqlClientPool
+      ).getProjectByEnvironmentId(eid);
+      await hasPermission('environment', 'view', {
+        project: project.id
+      });
+    }
+    const rows = await query(sqlClientPool, Sql.selectEnvironmentStorageByEnvironmentIdByDaysClaim({eid, limit, claim: args.claim, startDate: args.startDate, endDate: args.endDate}))
+    // @DEPRECATE when `bytesUsed` is completely removed, this can be reverted
+    return rows.map(row => ({ ...row, bytesUsed: row.kibUsed}));
+  }
+
   await hasPermission('environment', 'storage');
 
   const rows = await query(sqlClientPool, Sql.selectEnvironmentStorageByEnvironmentId(eid))

--- a/services/api/src/resources/environment/sql.ts
+++ b/services/api/src/resources/environment/sql.ts
@@ -136,13 +136,13 @@ export const Sql = {
       .toString(),
   selectEnvironmentStorageByEnvironmentIdByDaysClaim: ({
     eid,
-    limit,
+    lastDays,
     startDate,
     endDate,
     claim,
   }: {
     eid: number;
-    limit?: number;
+    lastDays?: number;
     startDate?: Date;
     endDate?: Date;
     claim?: string;
@@ -167,9 +167,9 @@ export const Sql = {
           if (endDate) {
             queryBuilder = queryBuilder.where('updated', '<=', endDate);
           }
-          if (limit) {
-            // last `limit` days including latest/today if found
-            queryBuilder = queryBuilder.where(knex.raw('DATEDIFF(CURRENT_DATE, updated) < ?', [limit]));
+          if (lastDays) {
+            // last `lastDays` days including latest/today if found
+            queryBuilder = queryBuilder.where(knex.raw('DATEDIFF(CURRENT_DATE, updated) < ?', [lastDays]));
           }
         })
         .as('subquery');

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -869,7 +869,7 @@ const typeDefs = gql`
     """
     Reference to EnvironmentStorage API Object, which shows the Storage consumption of this environment per day
     """
-    storages(startDate: Date, endDate: Date, limit: Int, claim: String): [EnvironmentStorage]
+    storages(startDate: Date, endDate: Date, lastDays: Int, claim: String): [EnvironmentStorage]
     """
     Reference to EnvironmentStorageMonth API Object, which returns how many storage per day this environment used in a specific month
     """

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -869,7 +869,7 @@ const typeDefs = gql`
     """
     Reference to EnvironmentStorage API Object, which shows the Storage consumption of this environment per day
     """
-    storages: [EnvironmentStorage]
+    storages(startDate: Date, endDate: Date, limit: Int, claim: String): [EnvironmentStorage]
     """
     Reference to EnvironmentStorageMonth API Object, which returns how many storage per day this environment used in a specific month
     """


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

Extends the storages resolver on environments to support optional date range, limits, and a specific claim name.
This also opens the resolver to non-platform users to query, as long as user has view permission on the environment.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closes
Maybe #1696 , we just ignore the hits endpoint as discussed in that issue since that endpoint isn't great as it is.
