### PR TITLE
feat: get backup by backup id and file by file id resolver

### DIFF
--- a/services/api/src/resolvers.js
+++ b/services/api/src/resolvers.js
@@ -98,6 +98,7 @@ const {
   uploadFilesForTask,
   deleteFilesForTask,
   getDownloadLink,
+  getDownloadLinkByTaskFileId,
 } = require('./resources/file/resolvers');
 
 const {
@@ -283,6 +284,7 @@ const {
   addRestore,
   getRestoreByBackupId,
   updateRestore,
+  getBackupDownloadLinkByBackupId,
   backupSubscriber,
   getRestoreLocation,
 } = require('./resources/backup/resolvers');
@@ -683,7 +685,9 @@ async function getResolvers() {
     checkBulkImportProjectsAndGroupsToOrganization,
     allPlatformUsers: getAllPlatformUsers,
     getAuditLogs,
-    listAllRetentionPolicies
+    listAllRetentionPolicies,
+    getBackupDownloadLinkByBackupId,
+    getDownloadLinkByTaskFileId,
   },
   Mutation: {
     addProblem,

--- a/services/api/src/resources/file/resolvers.ts
+++ b/services/api/src/resources/file/resolvers.ts
@@ -46,6 +46,23 @@ export const getDownloadLink: ResolverFn = async ({ s3Key }, input, { userActivi
   });
 };
 
+export const getDownloadLinkByTaskFileId: ResolverFn = async (
+  root,
+  { taskId, fileId },
+  { sqlClientPool, hasPermission, userActivityLogger }
+) => {
+  const rowsPerms = await query(sqlClientPool, taskSql.selectPermsForTask(taskId));
+
+  await hasPermission('task', 'view', {
+    project: R.path(['0', 'pid'], rowsPerms)
+  });
+
+  const rows = await query(sqlClientPool, Sql.selectTaskFileById(taskId, fileId));
+
+  const downloadUrl = await getDownloadLink(rows[0], {}, userActivityLogger)
+  return downloadUrl;
+}
+
 export const getFilesByTaskId: ResolverFn = async (
   { id: tid },
   _args,

--- a/services/api/src/resources/file/sql.ts
+++ b/services/api/src/resources/file/sql.ts
@@ -8,6 +8,13 @@ export const Sql = {
       .andWhere('s3_file.deleted', '0000-00-00 00:00:00')
       .orderBy('s3_file.created', 'desc')
       .toString(),
+  selectTaskFileById: (tid: number, fid: number) =>
+    knex('task_file')
+      .join('s3_file', 'task_file.fid', '=', 's3_file.id')
+      .where('task_file.tid', tid)
+      .andWhere('task_file.fid', fid)
+      .andWhere('s3_file.deleted', '0000-00-00 00:00:00')
+      .toString(),
   insertFile: ({
     id,
     filename,

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -1522,6 +1522,8 @@ const typeDefs = gql`
     allPlatformUsers(id: String, email: String, gitlabId: Int, role: PlatformRole): [User]
     getAuditLogs(input: AuditLogInput): [AuditLog]
     listAllRetentionPolicies(name: String, type: RetentionPolicyType): [RetentionPolicy]
+    getBackupDownloadLinkByBackupId(backupId: String!): String
+    getDownloadLinkByTaskFileId(taskId: Int!, fileId: Int!): String
   }
 
   type ProjectGroupsToOrganization {


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

Additional work to support #3929 with dedicated resolvers for requesting a file that only returns a single irem. Updating the UI to have a download button action that calls this specific resolver would indicate in the audit log a more direct action to request a file.

It would be worth exploring removing the `download` and `restoreLocation` field in the normal tasks and backups resolvers in the future though once the UI and other things are updated to use the dedicated download resolvers this PR would introduce. This would limit the possibility of false audit entries from someone simply running a query using the normal resolvers.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

