### PR TITLE
Feature - Environment Variable "Updated" field and pending update endpoint

### DIFF
--- a/services/api/database/migrations/20251019203621_add_updated_to_env_vars.js
+++ b/services/api/database/migrations/20251019203621_add_updated_to_env_vars.js
@@ -1,0 +1,25 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function(knex) {
+  return knex.schema
+  .alterTable('env_vars', (table) => {
+    table.datetime('updated').notNullable().defaultTo(knex.fn.now());
+  })
+  .raw("UPDATE env_vars SET updated='1970-01-01 00:00:00'");
+  // Note, we do the above update so that all _existing_ env vars are
+  // not picked up as needing to be deployed (since we're using 'updated' to track new/updated vars)
+  // but any newly created items will get the _current_ date/time
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function(knex) {
+return knex.schema
+  .alterTable('env_vars', (table) => {
+    table.dropColumn('updated');
+  })
+};

--- a/services/api/src/resolvers.js
+++ b/services/api/src/resolvers.js
@@ -130,6 +130,10 @@ const {
 } = require('./resources/environment/resolvers');
 
 const {
+  getPendingChangesByEnvironmentId,
+} = require('./resources/environment/environment_redeploy')
+
+const {
   getDeployTargetConfigById,
   getDeployTargetConfigsByProjectId,
   getDeployTargetConfigsByDeployTarget,
@@ -522,6 +526,7 @@ async function getResolvers() {
       facts: getFactsByEnvironmentId,
       openshift: getOpenshiftByEnvironmentId,
       kubernetes: getOpenshiftByEnvironmentId,
+      pendingChanges: getPendingChangesByEnvironmentId,
     },
     Organization: {
       groups: getGroupsByOrganizationId,

--- a/services/api/src/resources/env-variables/resolvers.ts
+++ b/services/api/src/resources/env-variables/resolvers.ts
@@ -417,6 +417,9 @@ export const addOrUpdateEnvVariableByName: ResolverFn = async (
     }
   }
 
+  // Let's set the updated value for the env var
+  updateData['updated'] = knex.fn.now();
+
   const createOrUpdateSql = knex('env_vars')
     .insert({
       ...updateData,

--- a/services/api/src/resources/environment/environment_redeploy.ts
+++ b/services/api/src/resources/environment/environment_redeploy.ts
@@ -35,38 +35,29 @@ _,
 
 const getPendingEnvVarChanges = async(sqlClientPool, envId) => {
       const sql = `
-    SELECT DISTINCT
-      ev.name,
-      ev.updated,
-      e.id,
-      e.name as env_name,
-	    COALESCE(
-	      IF(ev.environment IS NULL,NULL,'Environment'),
-	      IF(ev.project IS NULL,NULL,'Project'),
-	      IF(ev.organization IS NULL,NULL,'Organization')
-      ) as varsource,
-      COALESCE(MAX(d.created) OVER (PARTITION BY e.id), '1970-01-01') as last_deployment
-    FROM environment as e
-    LEFT JOIN deployment as d ON e.id = d.environment
-    INNER JOIN project as p ON p.id = e.project
-    LEFT JOIN organization as o ON o.id = p.organization
-    LEFT JOIN env_vars as ev ON (
-      ev.environment = e.id OR
-      ev.project = p.id OR
-      ev.organization = o.id
-    )
-    WHERE ev.name IS NOT NULL AND e.id = ?
-  `;
+select e.id as env_id, e.name as env_name, ev.name as envvar_name, ev.updated as envvar_updated,
+  COALESCE(
+    IF(ev.environment IS NULL,NULL,'Environment'),
+      IF(ev.project IS NULL,NULL,'Project'),
+      IF(ev.organization IS NULL,NULL,'Organization')
+      ) as envvar_source
+FROM environment as e
+INNER JOIN project as p ON p.id = e.project
+LEFT JOIN organization as o ON o.id = p.organization
+LEFT JOIN env_vars as ev ON (
+   ev.environment = e.id OR
+   ev.project = p.id OR
+   ev.organization = o.id
+)
+WHERE ev.name IS NOT NULL AND e.id = ?
+AND ev.updated > (select coalesce(max(completed), '0000-00-00 00:00:00') from deployment where environment = ? and status = ?)
+ORDER BY ev.updated asc
+`;
 
-  const results = await query(sqlClientPool, sql, [envId]);
+  const results = await query(sqlClientPool, sql, [envId, envId, 'complete']);
 
-  // Filter in memory for env vars updated after last deployment
-  const pendingChanges = results.filter(row => {
-    const updated = new Date(row.updated);
-    const lastDeployment = new Date(row.lastDeployment);
-    return updated > lastDeployment;
-  }).map(row => {
-    return {type:`Environment Variable - ${row.varsource} level`, details: row.name};
+  const pendingChanges = results.map(row => {
+    return {type:`Environment Variable - ${row.envvarSource} level`, details: row.envvarName, date: row.envvarUpdated};
   });
 
   return pendingChanges;

--- a/services/api/src/resources/environment/environment_redeploy.ts
+++ b/services/api/src/resources/environment/environment_redeploy.ts
@@ -63,7 +63,7 @@ const getPendingEnvVarChanges = async(sqlClientPool, envId) => {
   // Filter in memory for env vars updated after last deployment
   const pendingChanges = results.filter(row => {
     const updated = new Date(row.updated);
-    const lastDeployment = new Date(row.last_deployment);
+    const lastDeployment = new Date(row.lastDeployment);
     return updated > lastDeployment;
   }).map(row => {
     return {type:`Environment Variable - ${row.varsource} level`, details: row.name};

--- a/services/api/src/resources/environment/environment_redeploy.ts
+++ b/services/api/src/resources/environment/environment_redeploy.ts
@@ -64,7 +64,7 @@ const getPendingEnvVarChanges = async(sqlClientPool, envId) => {
   const pendingChanges = results.filter(row => {
     const updated = new Date(row.updated);
     const lastDeployment = new Date(row.last_deployment);
-    return updated > lastDeployment || true;
+    return updated > lastDeployment;
   }).map(row => {
     return {type:`Environment Variable - ${row.varsource} level`, details: row.name};
   });

--- a/services/api/src/resources/environment/environment_redeploy.ts
+++ b/services/api/src/resources/environment/environment_redeploy.ts
@@ -26,6 +26,9 @@ export const getPendingChangesByEnvironmentId: ResolverFn = async(
 _,
 { sqlClientPool, hasPermission },
 ) => {
+    // Note: as it stands, the only pending changes we have now have to do
+    // with env vars, but anything can be added in the form
+    // {type:"string", details:"string"}
     let pendingChanges = await getPendingEnvVarChanges(sqlClientPool, id);
     return pendingChanges;
 }

--- a/services/api/src/resources/environment/environment_redeploy.ts
+++ b/services/api/src/resources/environment/environment_redeploy.ts
@@ -93,7 +93,7 @@ ORDER BY allenvs.envvar_updated DESC;
   const results = await query(sqlClientPool, sql, [envId, envId, envId, envId]);
 
   const pendingChanges = results.map(row => {
-    return {type:`Environment Variable - ${row.envvarSource} level`, details: row.envvarName, date: row.envvarUpdated};
+    return {type:`${row.envvarSource} Environment Variable`, details: `Variable name: ${row.envvarName}`, date: row.envvarUpdated};
   });
 
   return pendingChanges;

--- a/services/api/src/resources/environment/environment_redeploy.ts
+++ b/services/api/src/resources/environment/environment_redeploy.ts
@@ -40,6 +40,11 @@ const getPendingEnvVarChanges = async(sqlClientPool, envId) => {
       ev.updated,
       e.id,
       e.name as env_name,
+	    COALESCE(
+	      IF(ev.environment IS NULL,NULL,'Environment'),
+	      IF(ev.project IS NULL,NULL,'Project'),
+	      IF(ev.organization IS NULL,NULL,'Organization')
+      ) as varsource,
       COALESCE(MAX(d.created) OVER (PARTITION BY e.id), '1970-01-01') as last_deployment
     FROM environment as e
     LEFT JOIN deployment as d ON e.id = d.environment
@@ -61,7 +66,7 @@ const getPendingEnvVarChanges = async(sqlClientPool, envId) => {
     const lastDeployment = new Date(row.last_deployment);
     return updated > lastDeployment || true;
   }).map(row => {
-    return {type:"Environment Variable", details: row.name};
+    return {type:`Environment Variable - ${row.varsource} level`, details: row.name};
   });
 
   return pendingChanges;

--- a/services/api/src/resources/environment/environment_redeploy.ts
+++ b/services/api/src/resources/environment/environment_redeploy.ts
@@ -28,7 +28,7 @@ _,
 ) => {
     // Note: as it stands, the only pending changes we have now have to do
     // with env vars, but anything can be added in the form
-    // {type:"string", details:"string"}
+    // {type:"string", details:"string", date: "string"}
     let pendingChanges = await getPendingEnvVarChanges(sqlClientPool, id);
     return pendingChanges;
 }

--- a/services/api/src/resources/environment/environment_redeploy.ts
+++ b/services/api/src/resources/environment/environment_redeploy.ts
@@ -36,7 +36,7 @@ _,
 const getPendingEnvVarChanges = async(sqlClientPool, envId) => {
       const sql = `
 WITH last_completed AS (
-  SELECT COALESCE(MAX(d.completed), TIMESTAMP('1970-01-01 00:00:00')) AS ts
+  SELECT COALESCE(MAX(d.created), TIMESTAMP('1970-01-01 00:00:00')) AS ts
   FROM deployment d
   WHERE d.environment = ? AND d.status = 'complete'
 )

--- a/services/api/src/resources/environment/environment_redeploy.ts
+++ b/services/api/src/resources/environment/environment_redeploy.ts
@@ -1,0 +1,65 @@
+// This file contains the logic to determine whether an environment requires a redeploy
+
+import * as R from 'ramda';
+import { sendToLagoonLogs } from '@lagoon/commons/dist/logs/lagoon-logger';
+import { createRemoveTask, seedNamespace } from '@lagoon/commons/dist/tasks';
+import { ResolverFn } from '..';
+import { logger } from '../../loggers/logger';
+import { isPatchEmpty, query, knex } from '../../util/db';
+import { convertDateToMYSQLDateFormat } from '../../util/convertDateToMYSQLDateTimeFormat';
+import { Helpers } from './helpers';
+import { Sql } from './sql';
+import { Sql as projectSql } from '../project/sql';
+import { Helpers as projectHelpers } from '../project/helpers';
+import { Helpers as openshiftHelpers } from '../openshift/helpers';
+import { Helpers as organizationHelpers } from '../organization/helpers';
+import { getFactFilteredEnvironmentIds } from '../fact/resolvers';
+import { getUserProjectIdsFromRoleProjectIds } from '../../util/auth';
+import { RemoveData, DeployType, AuditType } from '@lagoon/commons/dist/types';
+import { AuditLog } from '../audit/types';
+
+
+export const getPendingChangesByEnvironmentId: ResolverFn = async(
+{
+    id
+},
+_,
+{ sqlClientPool, hasPermission },
+) => {
+    let pendingChanges = await getPendingEnvVarChanges(sqlClientPool, id);
+    return pendingChanges;
+}
+
+const getPendingEnvVarChanges = async(sqlClientPool, envId) => {
+      const sql = `
+    SELECT DISTINCT
+      ev.name,
+      ev.updated,
+      e.id,
+      e.name as env_name,
+      COALESCE(MAX(d.created) OVER (PARTITION BY e.id), '1970-01-01') as last_deployment
+    FROM environment as e
+    LEFT JOIN deployment as d ON e.id = d.environment
+    INNER JOIN project as p ON p.id = e.project
+    LEFT JOIN organization as o ON o.id = p.organization
+    LEFT JOIN env_vars as ev ON (
+      ev.environment = e.id OR
+      ev.project = p.id OR
+      ev.organization = o.id
+    )
+    WHERE ev.name IS NOT NULL AND e.id = ?
+  `;
+
+  const results = await query(sqlClientPool, sql, [envId]);
+
+  // Filter in memory for env vars updated after last deployment
+  const pendingChanges = results.filter(row => {
+    const updated = new Date(row.updated);
+    const lastDeployment = new Date(row.last_deployment);
+    return updated > lastDeployment || true;
+  }).map(row => {
+    return {type:"Environment Variable", details: row.name};
+  });
+
+  return pendingChanges;
+}

--- a/services/api/src/resources/environment/environment_redeploy.ts
+++ b/services/api/src/resources/environment/environment_redeploy.ts
@@ -51,7 +51,7 @@ LEFT JOIN env_vars as ev ON (
 )
 WHERE ev.name IS NOT NULL AND e.id = ?
 AND ev.updated > (select coalesce(max(completed), '0000-00-00 00:00:00') from deployment where environment = ? and status = ?)
-ORDER BY ev.updated asc
+ORDER BY ev.updated desc
 `;
 
   const results = await query(sqlClientPool, sql, [envId, envId, 'complete']);

--- a/services/api/src/resources/environment/environment_redeploy.ts
+++ b/services/api/src/resources/environment/environment_redeploy.ts
@@ -19,6 +19,10 @@ import { RemoveData, DeployType, AuditType } from '@lagoon/commons/dist/types';
 import { AuditLog } from '../audit/types';
 
 
+export const environmentPendingChangeTypes = {
+  ENVVAR: "ENVVAR",
+};
+
 export const getPendingChangesByEnvironmentId: ResolverFn = async(
 {
     id
@@ -93,7 +97,7 @@ ORDER BY allenvs.envvar_updated DESC;
   const results = await query(sqlClientPool, sql, [envId, envId, envId, envId]);
 
   const pendingChanges = results.map(row => {
-    return {type:`${row.envvarSource} Environment Variable`, details: `Variable name: ${row.envvarName}`, date: row.envvarUpdated};
+    return {type:environmentPendingChangeTypes.ENVVAR, details: `Variable name: ${row.envvarName} (source: ${row.envvarSource} )`, date: row.envvarUpdated};
   });
 
   return pendingChanges;

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -897,6 +897,15 @@ const typeDefs = gql`
     openshiftProjectPattern: String @deprecated(reason: "No longer in use")
     kubernetes: Kubernetes
     kubernetesNamespacePattern: String @deprecated(reason: "No longer in use")
+    """
+    Pending changes tell us if we need to redeploy an environment
+    """
+    pendingChanges: [EnvironmentPendingChanges]
+  }
+
+  type EnvironmentPendingChanges {
+    type: String
+    details: String
   }
 
   type EnvironmentHitsMonth {
@@ -1005,6 +1014,7 @@ const typeDefs = gql`
     scope: String
     name: String
     value: String
+    updated: String
   }
 
   type Task {

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -904,9 +904,13 @@ const typeDefs = gql`
   }
 
   type EnvironmentPendingChanges {
-    type: String
+    type: EnvironmentPendingChangeType
     details: String
     date: String
+  }
+
+  enum EnvironmentPendingChangeType {
+    ENVVAR
   }
 
   type EnvironmentHitsMonth {

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -906,6 +906,7 @@ const typeDefs = gql`
   type EnvironmentPendingChanges {
     type: String
     details: String
+    date: String
   }
 
   type EnvironmentHitsMonth {


### PR DESCRIPTION
This PR introduces two things.

First, the API exposes a new set of data on the environments - namely, whether they have any pendingChanges.
These are simple, `{type:,details}` messages that indicate _that_ there are pending changes to an environment (with the implication being that a redeploy is necessary).

Secondly - it introduces an "updated" field to the environment variables table that keeps track of when the last time an env var was update. This is used to check, against the last deployment, whether or not a redeploy is necessary.



<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

Explain the **details** for making this change. What existing problem does the pull request solve?

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
