### PR TITLE
feat: add graphql-sse endpoint

### DIFF
--- a/services/api/package.json
+++ b/services/api/package.json
@@ -46,6 +46,7 @@
     "graphql": "^16.10.0",
     "graphql-iso-date": "^3.5.0",
     "graphql-redis-subscriptions": "^2.7.0",
+    "graphql-sse": "^2.5.4",
     "graphql-subscriptions": "^1.0.0",
     "graphql-tools": "^9.0.18",
     "graphql-type-json": "^0.3.0",

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -73,6 +73,7 @@ export const createServer = async () => {
           await User(modelClients).userLastAccessed(currentUser);
         } catch (e) {
           logger.error('Error loading user details for SSE subscription', e.message);
+          throw new AuthenticationError('Failed to load user context for SSE subscription');
         }
       }
 
@@ -138,6 +139,11 @@ export const createServer = async () => {
 
   const server = http.createServer(async (req, res) => {
     if (req.url?.startsWith('/graphql/stream')) {
+      const origin = process.env.CORS_ORIGIN || '*';
+      res.setHeader('Access-Control-Allow-Origin', origin);
+      res.setHeader('Access-Control-Allow-Credentials', 'true');
+      res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+      res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, apollo-require-preflight');
       try {
         await sseHandler(req, res);
       } catch (error: any) {
@@ -209,6 +215,7 @@ try {
             await User(modelClients).userLastAccessed(currentUser);
           } catch (e) {
             logger.error('Error loading user details for subscription', e.message);
+            throw new AuthenticationError('Failed to load user context for subscription');
           }
         }
 

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -16,6 +16,7 @@ import { keycloakHasPermission, legacyHasPermission } from './util/auth';
 import R from 'ramda';
 import { AuthenticationError } from 'apollo-server-express';
 const { useServer } = require('graphql-ws/lib/use/ws');
+const { createHandler } = require('graphql-sse/lib/use/http');
 
 export const createServer = async () => {
   logger.verbose('Starting the api...');
@@ -23,10 +24,137 @@ export const createServer = async () => {
   await configureApp();
 
   const port = toNumber(getConfigFromEnv('PORT', '3000'));
-  const server = http.createServer(app);
-  server.setTimeout(900000); // higher Server timeout: 15min instead of default 2min
 
-  // apolloServer.installSubscriptionHandlers(server);
+  const schema = await getSchema();
+
+  const sseHandler = createHandler({
+    schema: schema,
+    authenticate: async (req) => {
+      const authHeader = req.raw.headers.authorization || req.raw.headers.Authorization;
+
+      if (!authHeader) {
+        logger.error('SSE: No authorization header');
+        throw new AuthenticationError('Auth token missing.');
+      }
+
+      const authToken = authHeader.replace('Bearer ', '').replace('bearer ', '');
+
+      try {
+        const { grant, legacyCredentials } = await getGrantOrLegacyCredsFromToken(authToken);
+        return { grant, legacyCredentials };
+      } catch (e) {
+        logger.error(`SSE auth failed: ${e.message}`);
+        throw new AuthenticationError('Auth token invalid.');
+      }
+    },
+    context: async (req, params) => {
+      const { grant: keycloakGrant, legacyCredentials: legacyGrant } = req.context || {};
+
+      const keycloakAdminClient = await getKeycloakAdminClient();
+      const modelClients = { sqlClientPool, keycloakAdminClient, esClient };
+
+      let currentUser: any = { id: undefined };
+      let serviceAccount = {};
+      let keycloakUsersGroups = [];
+      let groupRoleProjectIds = [];
+      let platformOwner = false;
+      let platformViewer = false;
+
+      if (keycloakGrant) {
+        try {
+          const userId = keycloakGrant.access_token.content.sub;
+          keycloakUsersGroups = await User(modelClients).getAllGroupsForUser(userId);
+          serviceAccount = await keycloakGrantManager.obtainFromClientCredentials(undefined, undefined);
+          currentUser = await User(modelClients).loadUserById(userId);
+          const userRoleMapping = await keycloakAdminClient.users.listRealmRoleMappings({ id: currentUser.id });
+          platformOwner = userRoleMapping.some(role => role.name === 'platform-owner');
+          platformViewer = userRoleMapping.some(role => role.name === 'platform-viewer');
+          groupRoleProjectIds = await User(modelClients).getAllProjectsIdsForUser(currentUser.id, keycloakUsersGroups);
+          await User(modelClients).userLastAccessed(currentUser);
+        } catch (e) {
+          logger.error('Error loading user details for SSE subscription', e.message);
+        }
+      }
+
+      if (legacyGrant) {
+        const { role } = legacyGrant;
+        if (role === 'admin') {
+          platformOwner = true;
+        }
+      }
+
+      const hasPermission = keycloakGrant
+        ? keycloakHasPermission(keycloakGrant, modelClients, serviceAccount, currentUser, groupRoleProjectIds)
+        : legacyGrant
+        ? legacyHasPermission(legacyGrant)
+        : () => false;
+
+      logger.debug('SSE: Created context', {
+        hasKeycloakGrant: !!keycloakGrant,
+        hasLegacyGrant: !!legacyGrant,
+        platformOwner,
+        platformViewer
+      });
+
+      return {
+        keycloakAdminClient,
+        sqlClientPool,
+        hasPermission,
+        keycloakGrant,
+        legacyGrant,
+        models: {
+          UserModel: User(modelClients),
+          GroupModel: Group(modelClients),
+          EnvironmentModel: Environment(modelClients)
+        },
+        keycloakUsersGroups,
+        adminScopes: { platformOwner, platformViewer },
+      };
+    },
+    onSubscribe: async (req, params) => {
+      logger.debug('SSE onSubscribe', {
+        operationName: params?.operationName,
+        query: params?.query,
+        variables: params?.variables
+      });
+    },
+    onNext: (req, params, result) => {
+      logger.debug('SSE onNext', {
+        hasResult: !!result,
+        resultData: result?.data,
+        errors: result?.errors
+      });
+    },
+    onError: (req, params, errors) => {
+      logger.error('SSE onError', {
+        errors: errors,
+        params: params
+      });
+    },
+    onComplete: (req, params) => {
+      logger.verbose('SSE connection completed', { params });
+    },
+  });
+
+  const server = http.createServer(async (req, res) => {
+    if (req.url?.startsWith('/graphql/stream')) {
+      try {
+        await sseHandler(req, res);
+      } catch (error: any) {
+        logger.error('SSE handler error', {
+          error: error.message,
+          stack: error.stack
+        });
+        if (!res.headersSent) {
+          res.writeHead(500, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Internal server error' }));
+        }
+      }
+    } else {
+      app(req, res);
+    }
+  });
+  server.setTimeout(900000);
 
   async function setupGraphQLModules() {
 try {
@@ -214,6 +342,7 @@ try {
     wsServer
   );
   logger.info(`Subscription endpoint ready at ws://localhost:${port}/graphql`);
+  logger.info(`SSE subscription endpoint ready at http://localhost:${port}/graphql/stream`);
 
 } catch (error) {
   logger.error("Failed to load GraphQL modules:", error);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6209,6 +6209,11 @@ graphql-redis-subscriptions@^2.7.0:
   optionalDependencies:
     ioredis "^5.3.2"
 
+graphql-sse@^2.5.4:
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/graphql-sse/-/graphql-sse-2.5.4.tgz#29e93d8ccda58b9263b18f176b7be631638ec658"
+  integrity sha512-8PIGHQPv1vokYboL8KsoBomvyJCUMJCAwSp5f+bR2qVoYtPo7CYowrYV7LFiXuiirX0cxVzgUBFNa5BaI4rZ2A==
+
 graphql-subscriptions@^1.0.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/graphql-subscriptions/-/graphql-subscriptions-1.2.1.tgz#2142b2d729661ddf967b7388f7cf1dd4cf2e061d"


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

This adds `graphql-sse` to the API to support subscriptions over server sent events. 

This will allow us to deprecate `graphql-ws` or remove it entirely. The UI will need to be updated to use `graphql-sse` for subscriptions too.

This has some debugging loggers in there that probably need to be removed, or have the data contained in them trimmed down. I've left them there for the moment for troubleshooting if required.

You can use this locally with curl to view deployment changes for an environment
```
curl -X POST -N -H "Accept: text/event-stream" \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer ${TOKEN}" \
    "http://localhost:3000/graphql/stream" \
    -d '{"query":"subscription {deploymentChanged(environment: 3){id,name}}"}'
```