### PR TITLE
fix: update twuni docker registry URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -693,6 +693,7 @@ helm/repos: local-dev/helm
 	$(HELM) repo add metallb https://metallb.github.io/metallb
 	$(HELM) repo add jetstack https://charts.jetstack.io
 	$(HELM) repo add jouve https://jouve.github.io/charts/
+	$(HELM) repo remove twuni
 	$(HELM) repo add twuni https://twuni.github.io/docker-registry.helm
 	$(HELM) repo add k8up https://k8up-io.github.io/k8up
 	$(HELM) repo add appuio https://charts.appuio.ch

--- a/Makefile
+++ b/Makefile
@@ -693,7 +693,7 @@ helm/repos: local-dev/helm
 	$(HELM) repo add metallb https://metallb.github.io/metallb
 	$(HELM) repo add jetstack https://charts.jetstack.io
 	$(HELM) repo add jouve https://jouve.github.io/charts/
-	$(HELM) repo add twuni https://helm.twun.io
+	$(HELM) repo add twuni https://twuni.github.io/docker-registry.helm
 	$(HELM) repo add k8up https://k8up-io.github.io/k8up
 	$(HELM) repo add appuio https://charts.appuio.ch
 	$(HELM) repo add prometheus-community https://prometheus-community.github.io/helm-charts


### PR DESCRIPTION
# Description

As noted [here](https://github.com/twuni/docker-registry.helm), the helm repo URL for twuni's docker registry has been changed from https://helm.twun.io to https://twuni.github.io/docker-registry.helm

This PR updates this for the local-stack.
