### PR TITLE
fix: api error when accessing fields stored as `bigint`

### DIFF
--- a/services/api/src/clients/sqlClient.ts
+++ b/services/api/src/clients/sqlClient.ts
@@ -9,7 +9,8 @@ export const config = {
   password: getConfigFromEnv('API_DB_PASSWORD', 'api'),
   database: getConfigFromEnv('API_DB_DATABASE', 'infrastructure'),
   connectionLimit: toNumber(getConfigFromEnv('API_DB_CONN_LIMIT', '80')),
-  insertIdAsNumber: true
+  insertIdAsNumber: true,
+  bigIntAsNumber: true,
 };
 
 export const sqlClientPool = mariadb.createPool(config);


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Database Migrations

n/a

# Description

The mariadb client version was upgraded from 2.x to 3.x in https://github.com/uselagoon/lagoon/pull/4009 which caused an error to be thrown for any api fields stored as mariadb `bigint`. Fix is to configure the client to use the same conversion mechanism as 2.x.

It's also [documented that `decimal` fields](https://mariadb.com/docs/connectors/mariadb-connector-nodejs/connector-nodejs-promise-api#migrating-from-2.x-or-mysql-mysql2-to-3.x) have the same config option, but when I tested those fields in the api I didn't get any errors, so leaving that one as-is.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

n/a
