### PR TITLE
fix/refactor: getProjectByEnvironmentId helper and problems refs

### DIFF
--- a/services/api/src/resources/environment/helpers.ts
+++ b/services/api/src/resources/environment/helpers.ts
@@ -30,9 +30,21 @@ export const Helpers = (sqlClientPool: Pool) => {
     return R.prop(0, withK8s);
   };
 
+  const getEnvironmentProjectByEnvironmentId = async (
+    environmentId: number,
+    environmentType = []
+  ) => {
+    const rows = await query(
+      sqlClientPool,
+      Sql.selectEnvironmentProjectByEnvironmentId(environmentId, environmentType)
+    );
+    return R.prop(0, rows);
+  };
+
   return {
     aliasOpenshiftToK8s,
     getEnvironmentById,
+    getEnvironmentProjectByEnvironmentId,
     deleteEnvironment: async (name: string, eid: number, pid: number) => {
       const environmentData = await Helpers(sqlClientPool).getEnvironmentById(eid);
       const projectData = await projectHelpers(sqlClientPool).getProjectById(pid);

--- a/services/api/src/resources/environment/sql.ts
+++ b/services/api/src/resources/environment/sql.ts
@@ -210,6 +210,24 @@ export const Sql = {
       .where(knex.raw('environment_service.id = ?', id))
       .limit(1)
       .toString(),
+  selectEnvironmentProjectByEnvironmentId: (environmentId, environmentType = []) => {
+    let q = knex('environment as e')
+      .select(
+        'e.id',
+        { envName: 'e.name' },
+        'e.environment_type',
+        'e.project',
+        'e.openshift_project_name',
+        'p.name',
+        { projectId: 'p.id'}
+      )
+      .leftJoin('project as p', 'p.id', '=', 'e.project');
+    if (environmentType && environmentType.length > 0) {
+      q.where('e.environment_type', environmentType);
+    }
+    q.where('e.id', environmentId);
+    return q.toString();
+  },
   // sekect all the containers for a particular service
   selectContainersByServiceId: (id: number) =>
     knex('environment_service_container')

--- a/services/api/src/resources/problem/helpers.ts
+++ b/services/api/src/resources/problem/helpers.ts
@@ -1,7 +1,7 @@
 import * as R from 'ramda';
 import { Pool } from 'mariadb';
 import { query } from '../../util/db';
-import { Helpers as projectHelpers } from '../project/helpers';
+import { Helpers as environmentHelpers } from '../environment/helpers';
 import { Sql } from './sql';
 
 export const Helpers = (sqlClientPool: Pool) => {
@@ -48,7 +48,7 @@ export const Helpers = (sqlClientPool: Pool) => {
           envName,
           environmentType
         }: any =
-          (await projectHelpers(sqlClientPool).getProjectByEnvironmentId(
+          (await environmentHelpers(sqlClientPool).getEnvironmentProjectByEnvironmentId(
             problem.environment,
             envType
           )) || {};

--- a/services/api/src/resources/project/helpers.ts
+++ b/services/api/src/resources/project/helpers.ts
@@ -81,12 +81,11 @@ export const Helpers = (sqlClientPool: Pool) => {
   };
 
   const getProjectByEnvironmentId = async (
-    environmentId: number,
-    environmentType = []
+    environmentId: number
   ) => {
     const rows = await query(
       sqlClientPool,
-      Sql.selectProjectByEnvironmentId(environmentId, environmentType)
+      Sql.selectProjectByEnvironmentId(environmentId)
     );
     return R.prop(0, rows);
   };

--- a/services/api/src/resources/project/resolvers.ts
+++ b/services/api/src/resources/project/resolvers.ts
@@ -113,7 +113,7 @@ export const getProjectByEnvironmentId: ResolverFn = async (
   args,
   { sqlClientPool, hasPermission, adminScopes }
 ) => {
-  const rows = await query(sqlClientPool, Sql.selectProjectByEnvironmentID(eid));
+  const rows = await query(sqlClientPool, Sql.selectProjectByEnvironmentId(eid));
 
   const withK8s = Helpers(sqlClientPool).aliasOpenshiftToK8s(rows);
 

--- a/services/api/src/resources/project/sql.ts
+++ b/services/api/src/resources/project/sql.ts
@@ -54,7 +54,7 @@ export const Sql = {
     knex('project as p')
       .where('p.organization', organizationId)
       .toString(),
-  selectProjectByEnvironmentID: (id: number) =>
+  selectProjectByEnvironmentId: (id: number) =>
     knex('environment as e')
       .select('project.*')
       .join('project', 'e.project', '=', 'project.id')
@@ -86,24 +86,6 @@ export const Sql = {
       .where('e.project', '=', id)
       .andWhere('e.deleted', '0000-00-00 00:00:00')
       .toString(),
-  selectProjectByEnvironmentId: (environmentId, environmentType = []) => {
-    let q = knex('environment as e')
-      .select(
-        'e.id',
-        { envName: 'e.name' },
-        'e.environment_type',
-        'e.project',
-        'e.openshift_project_name',
-        'p.name',
-        { projectId: 'p.id'}
-      )
-      .leftJoin('project as p', 'p.id', '=', 'e.project');
-    if (environmentType && environmentType.length > 0) {
-      q.where('e.environment_type', environmentType);
-    }
-    q.where('e.id', environmentId);
-    return q.toString();
-  },
   updateProject: ({
     id,
     patch

--- a/services/api/src/resources/routes/resolvers.ts
+++ b/services/api/src/resources/routes/resolvers.ts
@@ -1196,16 +1196,16 @@ export const getRoutesByProjectId: ResolverFn = async (
 };
 
 /*
-  getRoutesByProjectId is used to query the routes attached to an environment
+  getRoutesByEnvironmentId is used to query the routes attached to an environment
 */
 export const getRoutesByEnvironmentId: ResolverFn = async (
   { id: environmentId },
   { domain, source },
   { sqlClientPool, hasPermission }
 ) => {
-  const { id: projectId } = await projectHelpers(sqlClientPool).getProjectByEnvironmentId(environmentId);
+  const projectData = await projectHelpers(sqlClientPool).getProjectByEnvironmentId(environmentId);
   await hasPermission('route', 'view', {
-    project: projectId
+    project: projectData.id
   });
 
   let queryBuilder = knex('routes')


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

The project helper called `getProjectByEnvironmentId` didn't actually retrieve the project, it returned the environment.

The only place I could see that used this helper was problems, so I moved the resolver into the environments helpers and renamed it.

Then fixed the `getProjectByEnvironmentId` helper to actually return the project correctly.

