### PR TITLE
Fixes otp list in lagoon theme

### DIFF
--- a/services/keycloak/themes/lagoon/login/login-config-totp.ftl
+++ b/services/keycloak/themes/lagoon/login/login-config-totp.ftl
@@ -10,7 +10,7 @@
                 <p>${msg("loginTotpStep1")}</p>
 
                 <ul id="kc-totp-supported-apps">
-                    <#list totp.policy.supportedApplications as app>
+                    <#list totp.supportedApplications as app>
                         <li>${msg(app)}</li>
                     </#list>
                 </ul>


### PR DESCRIPTION
In [this commit](https://github.com/keycloak/keycloak/commit/31aefd14893ac1ef1561fc40e76a44259c77e9dd) we see that there was a change in the way supported OTP integrations is exposed in the theming layer.

This PR brings the Lagoon theme in line with the current practice in Keycloak > v20.0.0


Testing instructions:
1 - spin up keycloak (either in localstack or using something like `make api-development`)
2 - create a user or pick an existing user in the `lagoon` realm (this can be done on the `master` realm, but be sure to change the theme for the realm to `lagoon`)
3 - edit the user, set a password, and on Details->Required user actions, select `Configure OTP`. Save.
4 - Log in as user from (2-3) and behold the OTP setup screen.

if you do steps (1-4) off `main` you'll hit an error after logging in, but with the change here you'll be able to set up your OTP and log in.