### PR TITLE
Change: Adds a migration to set a default value for metadata

### DIFF
--- a/services/api/database/migrations/20251112052711_set_default_metadata.js
+++ b/services/api/database/migrations/20251112052711_set_default_metadata.js
@@ -1,0 +1,21 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+// Need to utilize raw here instead of alterTable as MySQL requires
+// default values for JSON columns to be written as an expression
+exports.up = async function(knex) {
+  return knex.schema
+    .raw(`UPDATE project SET metadata = '{}' WHERE metadata IS NULL;`)
+    .raw(`ALTER TABLE project MODIFY metadata JSON NOT NULL DEFAULT ('{}');`);
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function(knex) {
+  return knex.schema
+    .raw(`ALTER TABLE project MODIFY metadata JSON NULL;`)
+    .raw(`UPDATE project SET metadata = NULL WHERE metadata = '{}';`);
+};

--- a/services/api/src/resources/project/resolvers.ts
+++ b/services/api/src/resources/project/resolvers.ts
@@ -1064,7 +1064,7 @@ export const updateProjectMetadata: ResolverFn = async (
   await query(
     sqlClientPool,
     `UPDATE project
-    SET metadata = JSON_SET(COALESCE(metadata, '{}'), :meta_key, :meta_value)
+    SET metadata = JSON_SET(metadata, :meta_key, :meta_value)
     WHERE id = :id`,
     {
       id,


### PR DESCRIPTION
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Database Migrations

- [x] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

Reverts the query change in [PR #4014](https://github.com/uselagoon/lagoon/pull/4014/files#diff-16177503259886f86d8e68b989d601c143690780b551d493170205e872a231a0R1067) & adds a migration to set a default value for `metadata`.

