### PR TITLE
fix: Better Environment Variable Precedence handling for pending deploys

### DIFF
--- a/services/api/src/resources/environment/environment_redeploy.ts
+++ b/services/api/src/resources/environment/environment_redeploy.ts
@@ -54,7 +54,7 @@ const getPendingEnvVarChanges = async(sqlClientPool, envId) => {
         ev.name AS envvar_name,
         ev.updated AS envvar_updated,
         lc.ts as env_last_updated,
-        IF(ev.updated > lc.ts, "deploy", "no-deploy") as must_deploy,
+        IF(ev.updated > lc.ts, 'deploy', 'no-deploy') as must_deploy,
         'Environment' AS envvar_source,
         3 as envvar_priority
       FROM environment e
@@ -71,7 +71,7 @@ const getPendingEnvVarChanges = async(sqlClientPool, envId) => {
         ev.name AS envvar_name,
         ev.updated AS envvar_updated,
         lc.ts as env_last_updated,
-        IF(ev.updated > lc.ts, "deploy", "no-deploy") as must_deploy,
+        IF(ev.updated > lc.ts, 'deploy', 'no-deploy') as must_deploy,
         'Project' AS envvar_source,
         2 as envvar_priority
       FROM environment e
@@ -89,7 +89,7 @@ const getPendingEnvVarChanges = async(sqlClientPool, envId) => {
         ev.name AS envvar_name,
         ev.updated AS envvar_updated,
         lc.ts as env_last_updated,
-        IF(ev.updated > lc.ts, "deploy", "no-deploy") as must_deploy,
+        IF(ev.updated > lc.ts, 'deploy', 'no-deploy') as must_deploy,
         'Organization' AS envvar_source,
         1 as envvar_priority
       FROM environment e
@@ -106,25 +106,25 @@ const getPendingEnvVarChanges = async(sqlClientPool, envId) => {
 
   const results = await query(sqlClientPool, sql, [envId, envId, envId, envId]);
 
-  const overrideMap = new Map()
+  const overrideMap = new Map();
 
   const shouldDeployDBString = "deploy";
   results.forEach((row) => {
       if (overrideMap.has(row.envvarName)) { // Check if there is already an instance of this var
-          let other = overrideMap.get(row.envvarName)
+          let other = overrideMap.get(row.envvarName);
           if(row.envvarPriority > other.envvarPriority) { // if this is higher
               if(row.mustDeploy === shouldDeployDBString) {
                   // We override conventionally
-                  overrideMap.set(row.envvarName, row)
+                  overrideMap.set(row.envvarName, row);
               } else {
                   // We override without any deployment - remove
-                  overrideMap.delete(row.envvarName)
+                  overrideMap.delete(row.envvarName);
               }
           }
       } else {
           if(row.mustDeploy === shouldDeployDBString) {
               // First instance of a var to be deployed
-              overrideMap.set(row.envvarName, row)
+              overrideMap.set(row.envvarName, row);
           }
       }
   })
@@ -134,7 +134,7 @@ const getPendingEnvVarChanges = async(sqlClientPool, envId) => {
         type:environmentPendingChangeTypes.ENVVAR,
         details: `Variable name: ${row.envvarName} (source: ${row.envvarSource} )`,
         date: row.envvarUpdated
-      }
+      };
   })
 
   return pendingChanges;

--- a/services/api/src/resources/environment/environment_redeploy.ts
+++ b/services/api/src/resources/environment/environment_redeploy.ts
@@ -108,32 +108,33 @@ ORDER BY allenvs.envvar_priority ASC;
 
 let overrideMap = new Map()
 
-results.reduce((ac: Map<string, any>, row) => {
-    if (ac.has(row.envvarName)) { // Check if there is already an instance of this var
-        let other = ac.get(row.envvarName)
+results.forEach((row) => {
+    if (overrideMap.has(row.envvarName)) { // Check if there is already an instance of this var
+        let other = overrideMap.get(row.envvarName)
         if(row.envvarPriority > other.envvarPriority) { // if this is higher
             if(row.mustDeploy === "deploy") {
                 // We override conventionally
-                ac.set(row.envvarName, row)
+                overrideMap.set(row.envvarName, row)
             } else {
                 // We override without any deployment - remove
-                ac.set(row.envvarName, null)
+                // ac.set(row.envvarName, null)
+                overrideMap.delete(row.envvarName)
             }
         }
     } else {
         if(row.mustDeploy === "deploy") {
             // First instance of a var to be deployed
-            ac.set(row.envvarName, row)
+            overrideMap.set(row.envvarName, row)
         }
     }
-    return ac
-}, overrideMap)
+})
 
-  const pendingChanges = [];
-  overrideMap.forEach((row) => {
-    if (row !== null) {
-      pendingChanges.push({type:environmentPendingChangeTypes.ENVVAR, details: `Variable name: ${row.envvarName} (source: ${row.envvarSource} )`, date: row.envvarUpdated})
-    }
+  const pendingChanges =  Array.from(overrideMap.values()).map((row) => {
+      return {
+        type:environmentPendingChangeTypes.ENVVAR,
+        details: `Variable name: ${row.envvarName} (source: ${row.envvarSource} )`,
+        date: row.envvarUpdated
+      }
   })
 
   return pendingChanges;

--- a/services/api/src/resources/environment/environment_redeploy.ts
+++ b/services/api/src/resources/environment/environment_redeploy.ts
@@ -129,7 +129,7 @@ results.reduce((ac: Map<string, any>, row) => {
     return ac
 }, overrideMap)
 
-  let pendingChanges = [];
+  const pendingChanges = [];
   overrideMap.forEach((row) => {
     if (row !== null) {
       pendingChanges.push({type:environmentPendingChangeTypes.ENVVAR, details: `Variable name: ${row.envvarName} (source: ${row.envvarSource} )`, date: row.envvarUpdated})

--- a/services/api/src/resources/environment/environment_redeploy.ts
+++ b/services/api/src/resources/environment/environment_redeploy.ts
@@ -39,95 +39,96 @@ _,
 
 const getPendingEnvVarChanges = async(sqlClientPool, envId) => {
 
-      const sql = `
-WITH last_completed AS (
-  SELECT COALESCE(MAX(d.created), TIMESTAMP('1970-01-01 00:00:00')) AS ts
-  FROM deployment d
-  WHERE d.environment = ? AND d.status = 'complete'
-)
-SELECT *
-FROM (
-  -- Environment-scoped
-  SELECT
-    e.id   AS env_id,
-    e.name AS env_name,
-    ev.name AS envvar_name,
-    ev.updated AS envvar_updated,
-    lc.ts as env_last_updated,
-    IF(ev.updated > lc.ts, "deploy", "no-deploy") as must_deploy,
-    'Environment' AS envvar_source,
-    3 as envvar_priority
-  FROM environment e
-  JOIN env_vars ev ON ev.environment = e.id
-  CROSS JOIN last_completed lc
-  WHERE e.id = ?
-    AND ev.name IS NOT NULL
+  const sql = `
+    WITH last_completed AS (
+      SELECT COALESCE(MAX(d.created), TIMESTAMP('1970-01-01 00:00:00')) AS ts
+      FROM deployment d
+      WHERE d.environment = ? AND d.status = 'complete'
+    )
+    SELECT *
+    FROM (
+      -- Environment-scoped
+      SELECT
+        e.id   AS env_id,
+        e.name AS env_name,
+        ev.name AS envvar_name,
+        ev.updated AS envvar_updated,
+        lc.ts as env_last_updated,
+        IF(ev.updated > lc.ts, "deploy", "no-deploy") as must_deploy,
+        'Environment' AS envvar_source,
+        3 as envvar_priority
+      FROM environment e
+      JOIN env_vars ev ON ev.environment = e.id
+      CROSS JOIN last_completed lc
+      WHERE e.id = ?
+        AND ev.name IS NOT NULL
 
-  UNION ALL
+      UNION ALL
 
-  -- Project-scoped
-  SELECT
-    e.id, e.name,
-    ev.name AS envvar_name,
-    ev.updated AS envvar_updated,
-    lc.ts as env_last_updated,
-    IF(ev.updated > lc.ts, "deploy", "no-deploy") as must_deploy,
-    'Project' AS envvar_source,
-    2 as envvar_priority
-  FROM environment e
-  JOIN project p   ON p.id = e.project
-  JOIN env_vars ev ON ev.project = p.id
-  CROSS JOIN last_completed lc
-  WHERE e.id = ?
-    AND ev.name IS NOT NULL
+      -- Project-scoped
+      SELECT
+        e.id, e.name,
+        ev.name AS envvar_name,
+        ev.updated AS envvar_updated,
+        lc.ts as env_last_updated,
+        IF(ev.updated > lc.ts, "deploy", "no-deploy") as must_deploy,
+        'Project' AS envvar_source,
+        2 as envvar_priority
+      FROM environment e
+      JOIN project p   ON p.id = e.project
+      JOIN env_vars ev ON ev.project = p.id
+      CROSS JOIN last_completed lc
+      WHERE e.id = ?
+        AND ev.name IS NOT NULL
 
-  UNION ALL
+      UNION ALL
 
-  -- Organization-scoped
-  SELECT
-    e.id, e.name,
-    ev.name AS envvar_name,
-    ev.updated AS envvar_updated,
-    lc.ts as env_last_updated,
-    IF(ev.updated > lc.ts, "deploy", "no-deploy") as must_deploy,
-    'Organization' AS envvar_source,
-    1 as envvar_priority
-  FROM environment e
-  JOIN project p        ON p.id = e.project
-  JOIN organization o   ON o.id = p.organization
-  JOIN env_vars ev      ON ev.organization = o.id
-  CROSS JOIN last_completed lc
-  WHERE e.id = ?
-    AND ev.name IS NOT NULL
+      -- Organization-scoped
+      SELECT
+        e.id, e.name,
+        ev.name AS envvar_name,
+        ev.updated AS envvar_updated,
+        lc.ts as env_last_updated,
+        IF(ev.updated > lc.ts, "deploy", "no-deploy") as must_deploy,
+        'Organization' AS envvar_source,
+        1 as envvar_priority
+      FROM environment e
+      JOIN project p        ON p.id = e.project
+      JOIN organization o   ON o.id = p.organization
+      JOIN env_vars ev      ON ev.organization = o.id
+      CROSS JOIN last_completed lc
+      WHERE e.id = ?
+        AND ev.name IS NOT NULL
 
-) AS allenvs
-ORDER BY allenvs.envvar_priority ASC;
-`;
+    ) AS allenvs
+    ORDER BY allenvs.envvar_priority ASC;
+  `;
 
   const results = await query(sqlClientPool, sql, [envId, envId, envId, envId]);
 
-let overrideMap = new Map()
+  const overrideMap = new Map()
 
-results.forEach((row) => {
-    if (overrideMap.has(row.envvarName)) { // Check if there is already an instance of this var
-        let other = overrideMap.get(row.envvarName)
-        if(row.envvarPriority > other.envvarPriority) { // if this is higher
-            if(row.mustDeploy === "deploy") {
-                // We override conventionally
-                overrideMap.set(row.envvarName, row)
-            } else {
-                // We override without any deployment - remove
-                // ac.set(row.envvarName, null)
-                overrideMap.delete(row.envvarName)
-            }
-        }
-    } else {
-        if(row.mustDeploy === "deploy") {
-            // First instance of a var to be deployed
-            overrideMap.set(row.envvarName, row)
-        }
-    }
-})
+  const shouldDeployDBString = "deploy";
+  results.forEach((row) => {
+      if (overrideMap.has(row.envvarName)) { // Check if there is already an instance of this var
+          let other = overrideMap.get(row.envvarName)
+          if(row.envvarPriority > other.envvarPriority) { // if this is higher
+              if(row.mustDeploy === shouldDeployDBString) {
+                  // We override conventionally
+                  overrideMap.set(row.envvarName, row)
+              } else {
+                  // We override without any deployment - remove
+                  // ac.set(row.envvarName, null)
+                  overrideMap.delete(row.envvarName)
+              }
+          }
+      } else {
+          if(row.mustDeploy === shouldDeployDBString) {
+              // First instance of a var to be deployed
+              overrideMap.set(row.envvarName, row)
+          }
+      }
+  })
 
   const pendingChanges =  Array.from(overrideMap.values()).map((row) => {
       return {

--- a/services/api/src/resources/environment/environment_redeploy.ts
+++ b/services/api/src/resources/environment/environment_redeploy.ts
@@ -68,7 +68,7 @@ FROM (
   -- Project-scoped
   SELECT
     e.id, e.name,
-    ev.name,
+    ev.name AS envvar_name,
     ev.updated AS envvar_updated,
     lc.ts as env_last_updated,
     IF(ev.updated > lc.ts, "deploy", "no-deploy") as must_deploy,
@@ -86,7 +86,7 @@ FROM (
   -- Organization-scoped
   SELECT
     e.id, e.name,
-    ev.name,
+    ev.name AS envvar_name,
     ev.updated AS envvar_updated,
     lc.ts as env_last_updated,
     IF(ev.updated > lc.ts, "deploy", "no-deploy") as must_deploy,
@@ -109,21 +109,21 @@ ORDER BY allenvs.envvar_priority ASC;
 let overrideMap = new Map()
 
 results.reduce((ac: Map<string, any>, row) => {
-    if (ac.has(row.name)) { // Check if there is already an instance of this var
-        let other = ac.get(row.name)
+    if (ac.has(row.envvarName)) { // Check if there is already an instance of this var
+        let other = ac.get(row.envvarName)
         if(row.envvarPriority > other.envvarPriority) { // if this is higher
             if(row.mustDeploy == "deploy") {
                 // We override conventionally
-                ac.set(row.name, row)
+                ac.set(row.envvarName, row)
             } else {
                 // We override without any deployment - remove
-                ac.set(row.name, null)
+                ac.set(row.envvarName, null)
             }
         }
     } else {
         if(row.mustDeploy == "deploy") {
             // First instance of a var to be deployed
-            ac.set(row.name, row)
+            ac.set(row.envvarName, row)
         }
     }
     return ac

--- a/services/api/src/resources/environment/environment_redeploy.ts
+++ b/services/api/src/resources/environment/environment_redeploy.ts
@@ -132,7 +132,7 @@ const getPendingEnvVarChanges = async(sqlClientPool, envId) => {
   const pendingChanges =  Array.from(overrideMap.values()).map((row) => {
       return {
         type:environmentPendingChangeTypes.ENVVAR,
-        details: `Variable name: ${row.envvarName} (source: ${row.envvarSource} )`,
+        details: `Variable name: ${row.envvarName} (source: ${row.envvarSource})`,
         date: row.envvarUpdated
       };
   })

--- a/services/api/src/resources/environment/environment_redeploy.ts
+++ b/services/api/src/resources/environment/environment_redeploy.ts
@@ -118,7 +118,6 @@ const getPendingEnvVarChanges = async(sqlClientPool, envId) => {
                   overrideMap.set(row.envvarName, row)
               } else {
                   // We override without any deployment - remove
-                  // ac.set(row.envvarName, null)
                   overrideMap.delete(row.envvarName)
               }
           }

--- a/services/api/src/resources/environment/environment_redeploy.ts
+++ b/services/api/src/resources/environment/environment_redeploy.ts
@@ -131,7 +131,9 @@ results.reduce((ac: Map<string, any>, row) => {
 
   let pendingChanges = [];
   overrideMap.forEach((row) => {
-    pendingChanges.push({type:environmentPendingChangeTypes.ENVVAR, details: `Variable name: ${row.envvarName} (source: ${row.envvarSource} )`, date: row.envvarUpdated})
+    if (row !== null) {
+      pendingChanges.push({type:environmentPendingChangeTypes.ENVVAR, details: `Variable name: ${row.envvarName} (source: ${row.envvarSource} )`, date: row.envvarUpdated})
+    }
   })
 
   return pendingChanges;

--- a/services/api/src/resources/environment/environment_redeploy.ts
+++ b/services/api/src/resources/environment/environment_redeploy.ts
@@ -112,7 +112,7 @@ results.reduce((ac: Map<string, any>, row) => {
     if (ac.has(row.envvarName)) { // Check if there is already an instance of this var
         let other = ac.get(row.envvarName)
         if(row.envvarPriority > other.envvarPriority) { // if this is higher
-            if(row.mustDeploy == "deploy") {
+            if(row.mustDeploy === "deploy") {
                 // We override conventionally
                 ac.set(row.envvarName, row)
             } else {
@@ -121,7 +121,7 @@ results.reduce((ac: Map<string, any>, row) => {
             }
         }
     } else {
-        if(row.mustDeploy == "deploy") {
+        if(row.mustDeploy === "deploy") {
             // First instance of a var to be deployed
             ac.set(row.envvarName, row)
         }


### PR DESCRIPTION
The logic of the current pending deploy has an inaccuracy.

Given the possibility of defining an env var at three different levels
- Org
- Project
- Environment
and given that the _same_ environment variable can (1) appear at every level, but (2) only the most _specific_ instance of the defined variable will be deployed into the environment (so something defined at both Project and Environment levels will see only the environment variable be deployed), this same logic of precedence should apply to what kind of "pending changes" show up for an environment.

This change will deal with this case generally AND with the case where an environment on a higher level might be considered as a pending change, but because the variable at the lower level has been successfully deployed into the environment, it is disregarded.

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

Explain the **details** for making this change. What existing problem does the pull request solve?

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
