### PR TITLE
feat: change build name for variable only deployments

### DIFF
--- a/node-packages/commons/src/api.ts
+++ b/node-packages/commons/src/api.ts
@@ -3,7 +3,7 @@ import { Transport } from './lokka-transport-http-retry';
 import { replace, pipe, toLower } from 'ramda';
 import { getConfigFromEnv } from './util/config';
 
-import { DeploymentSourceType, DeployType, TaskStatusType, TaskSourceType } from './types';
+import { DeploymentSourceType, DeploymentBuildType, DeployType, TaskStatusType, TaskSourceType } from './types';
 
 export interface Project {
   autoIdle: number;
@@ -1190,12 +1190,13 @@ export const addDeployment = (
   bulkName: string | null = null,
   sourceUser: string | null = null,
   sourceType: DeploymentSourceType,
+  buildType: DeploymentBuildType,
 ): Promise<any> =>
   graphqlapi.mutate(
     `
   ($name: String!, $status: DeploymentStatusType!, $created: String!, $environment: Int!, $id: Int, $remoteId: String,
     $started: String, $completed: String, $priority: Int, $bulkId: String, $bulkName: String,
-    $sourceUser: String, $sourceType: DeploymentSourceType) {
+    $sourceUser: String, $sourceType: DeploymentSourceType, $buildType: DeploymentBuildType) {
     addDeployment(input: {
         name: $name
         status: $status
@@ -1210,6 +1211,7 @@ export const addDeployment = (
         bulkName: $bulkName
         sourceUser: $sourceUser
         sourceType: $sourceType
+        buildType: $buildType
     }) {
       ...${deploymentFragment}
     }

--- a/node-packages/commons/src/tasks.ts
+++ b/node-packages/commons/src/tasks.ts
@@ -352,6 +352,7 @@ export const getControllerBuildData = async function(deployTarget: any, deployDa
     bulkId,
     bulkName,
     sourceType,
+    buildType,
   } = deployData;
 
   const buildVariables = deployData.buildVariables || [];
@@ -543,6 +544,7 @@ export const getControllerBuildData = async function(deployTarget: any, deployDa
       bulkName,
       sourceUser,
       sourceType,
+      buildType,
     );
   } catch (error) {
     logger.error(`Could not save deployment for project ${lagoonProjectData.id}. Message: ${error}`);

--- a/node-packages/commons/src/types.ts
+++ b/node-packages/commons/src/types.ts
@@ -17,6 +17,11 @@ export enum DeploymentSourceType {
   WEBHOOK = 'webhook'
 }
 
+export enum DeploymentBuildType {
+  BUILD = 'build',
+  VARIABLES = 'variables'
+}
+
 export enum TaskStatusType {
   NEW = 'new',
   PENDING = 'pending',
@@ -91,6 +96,7 @@ export interface DeployData {
   sha?: string,
   sourceType: DeploymentSourceType,
   sourceUser?: string,
+  buildType?: DeploymentBuildType,
   type: DeployType;
 }
 

--- a/node-packages/commons/src/util/lagoon.ts
+++ b/node-packages/commons/src/util/lagoon.ts
@@ -4,6 +4,9 @@ import { EnvKeyValue } from '../api';
 export const generateBuildId = () =>
   `lagoon-build-${Math.random().toString(36).substring(7)}`;
 
+export const variableOnlyBuild = () =>
+  `lagoon-variables-${Math.random().toString(36).substring(7)}`;
+
 export const generateTaskName = () =>
   `lagoon-task-${Math.random().toString(36).substring(7)}`;
 

--- a/node-packages/commons/src/util/lagoon.ts
+++ b/node-packages/commons/src/util/lagoon.ts
@@ -4,7 +4,7 @@ import { EnvKeyValue } from '../api';
 export const generateBuildId = () =>
   `lagoon-build-${Math.random().toString(36).substring(7)}`;
 
-export const variableOnlyBuild = () =>
+export const generateVariableOnlyBuildId = () =>
   `lagoon-variables-${Math.random().toString(36).substring(7)}`;
 
 export const generateTaskName = () =>

--- a/services/api/database/migrations/20251115000000_buildtype.js
+++ b/services/api/database/migrations/20251115000000_buildtype.js
@@ -1,0 +1,24 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+ exports.up = async function(knex) {
+    return knex.schema
+    .alterTable('deployment', (table) => {
+        table.enu('build_type',['build','variables']).notNullable().defaultTo('build');;
+    })
+    // set all existing deployments to build
+    .raw("UPDATE deployment SET build_type='build'");
+};
+
+/**
+* @param { import("knex").Knex } knex
+* @returns { Promise<void> }
+*/
+exports.down = async function(knex) {
+    // cant alter enums in place, so drop the column first :D
+    return knex.schema
+    .alterTable('deployment', (table) => {
+        table.dropColumn('build_type');
+    })
+};

--- a/services/api/src/resolvers.js
+++ b/services/api/src/resolvers.js
@@ -402,6 +402,10 @@ async function getResolvers() {
       API: 'api',
       WEBHOOK: 'webhook'
     },
+    DeploymentBuildType: {
+      BUILD: 'build',
+      VARIABLES: 'variables'
+    },
     TaskSourceType: {
       API: 'api',
     },

--- a/services/api/src/resources/deployment/resolvers.ts
+++ b/services/api/src/resources/deployment/resolvers.ts
@@ -30,7 +30,7 @@ import { jsonMerge } from '@lagoon/commons/dist/util/func';
 import { logger } from '../../loggers/logger';
 import { getUserProjectIdsFromRoleProjectIds } from '../../util/auth';
 import uuid4 from 'uuid4';
-import { DeploymentSourceType, DeployType, TaskStatusType, TaskSourceType, DeployData, AuditType } from '@lagoon/commons/dist/types';
+import { DeploymentSourceType, DeployType, TaskStatusType, TaskSourceType, DeployData, AuditType, DeploymentBuildType } from '@lagoon/commons/dist/types';
 import { AuditLog } from '../audit/types';
 
 const accessKeyId =  process.env.S3_FILES_ACCESS_KEY_ID || 'minio'
@@ -780,9 +780,11 @@ export const deployEnvironmentLatest: ResolverFn = async (
   }
 
   let buildName = generateBuildId();
+  let buildType = DeploymentBuildType.BUILD
   // change the buildname to a variables only name if the build variable for lagoon variables only is found
   if (buildVariables.find(e => e.name === 'LAGOON_VARIABLES_ONLY' && e.value === "true")) {
     buildName = variableOnlyBuild();
+    buildType = DeploymentBuildType.VARIABLES
   }
 
   const sourceUser = await Helpers(sqlClientPool).getSourceUser(keycloakGrant, legacyGrant)
@@ -805,7 +807,8 @@ export const deployEnvironmentLatest: ResolverFn = async (
         buildVariables: buildVariables,
         sourceType: DeploymentSourceType.API,
         sourceUser: sourceUser,
-        branchName: environment.deployBaseRef
+        branchName: environment.deployBaseRef,
+        buildType: buildType
       };
       meta = {
         ...meta,

--- a/services/api/src/resources/deployment/resolvers.ts
+++ b/services/api/src/resources/deployment/resolvers.ts
@@ -25,7 +25,7 @@ import { addTask } from '@lagoon/commons/dist/api';
 import { Sql as environmentSql } from '../environment/sql';
 const { S3Client, GetObjectCommand } = require('@aws-sdk/client-s3');
 import sha1 from 'sha1';
-import { generateBuildId } from '@lagoon/commons/dist/util/lagoon';
+import { generateBuildId, variableOnlyBuild } from '@lagoon/commons/dist/util/lagoon';
 import { jsonMerge } from '@lagoon/commons/dist/util/func';
 import { logger } from '../../loggers/logger';
 import { getUserProjectIdsFromRoleProjectIds } from '../../util/auth';
@@ -780,6 +780,11 @@ export const deployEnvironmentLatest: ResolverFn = async (
   }
 
   let buildName = generateBuildId();
+  // change the buildname to a variables only name if the build variable for lagoon variables only is found
+  if (buildVariables.find(e => e.name === 'LAGOON_VARIABLES_ONLY' && e.value === "true")) {
+    buildName = variableOnlyBuild();
+  }
+
   const sourceUser = await Helpers(sqlClientPool).getSourceUser(keycloakGrant, legacyGrant)
   let deployData: DeployData;
   let meta: {

--- a/services/api/src/resources/deployment/resolvers.ts
+++ b/services/api/src/resources/deployment/resolvers.ts
@@ -782,7 +782,7 @@ export const deployEnvironmentLatest: ResolverFn = async (
   let buildName = generateBuildId();
   let buildType = DeploymentBuildType.BUILD
   // change the buildname to a variables only name if the build variable for lagoon variables only is found
-  if (buildVariables.find(e => e.name === 'LAGOON_VARIABLES_ONLY' && e.value === "true")) {
+  if (buildVariables && buildVariables.find(e => e.name === 'LAGOON_VARIABLES_ONLY' && e.value === "true")) {
     buildName = variableOnlyBuild();
     buildType = DeploymentBuildType.VARIABLES
   }

--- a/services/api/src/resources/deployment/resolvers.ts
+++ b/services/api/src/resources/deployment/resolvers.ts
@@ -25,7 +25,7 @@ import { addTask } from '@lagoon/commons/dist/api';
 import { Sql as environmentSql } from '../environment/sql';
 const { S3Client, GetObjectCommand } = require('@aws-sdk/client-s3');
 import sha1 from 'sha1';
-import { generateBuildId, variableOnlyBuild } from '@lagoon/commons/dist/util/lagoon';
+import { generateBuildId, generateVariableOnlyBuildId } from '@lagoon/commons/dist/util/lagoon';
 import { jsonMerge } from '@lagoon/commons/dist/util/func';
 import { logger } from '../../loggers/logger';
 import { getUserProjectIdsFromRoleProjectIds } from '../../util/auth';
@@ -783,7 +783,7 @@ export const deployEnvironmentLatest: ResolverFn = async (
   let buildType = DeploymentBuildType.BUILD
   // change the buildname to a variables only name if the build variable for lagoon variables only is found
   if (buildVariables && buildVariables.find(e => e.name === 'LAGOON_VARIABLES_ONLY' && e.value === "true")) {
-    buildName = variableOnlyBuild();
+    buildName = generateVariableOnlyBuildId();
     buildType = DeploymentBuildType.VARIABLES
   }
 

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -147,6 +147,11 @@ const typeDefs = gql`
     API
   }
 
+  enum DeploymentBuildType {
+    BUILD
+    VARIABLES
+  }
+
   scalar SeverityScore
 
   type AdvancedTaskDefinitionArgument {
@@ -1007,6 +1012,7 @@ const typeDefs = gql`
     The source of this task from the available deplyoment trigger types
     """
     sourceType: DeploymentSourceType
+    buildType: DeploymentBuildType
   }
 
   type Insight {
@@ -1999,6 +2005,7 @@ const typeDefs = gql`
     buildStep: String
     sourceUser: String
     sourceType: DeploymentSourceType
+    buildType: DeploymentBuildType
   }
 
   input DeleteDeploymentInput {


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [x] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

Extends deployment type with a new field `buildType` that is an enum, the default is `BUILD`, but also supports `VARIABLES`. This will change depending on if the build has been flagged to be a [variables only deployment](https://github.com/uselagoon/build-deploy-tool/pull/430). The existence of the variables only deployment flag also changes the name of the build to be `lagoon-variables-xyz` instead of `lagoon-build-xyz` to also differentiate in the list of deployments. The `CONTAINER_REGISTRY` scope should be treated the same as `BUILD`, as it is only consumed during a build.

# Usage
An example of triggering a variables only deployment. This sets the build variable `LAGOON_VARIABLES_ONLY` to true.
```
mutation deployEnvironmentLatest{
	deployEnvironmentLatest(input:{
  	environment:{
    	id: 3
      project: {
      	id: 18
      }
    }
    buildVariables: [
    	{name: "LAGOON_VARIABLES_ONLY", value: "true"}
    ]
    returnData: true
  })
}
```

# Limitations
Variables only deployments have some limitations. Only `RUNTIME` and `GLOBAL` scope are considered as being changed (`GLOBAL` because it is considered `RUNTIME` and `BUILD`). However, if the variable being changed is `GLOBAL` or `BUILD` and is required to influence the outcome of built images, or change behaviour of something during a build, then a full deployment would be required. In the event that a `GLOBAL` scope is changed, only the runtime version of that variable will be updated in the environment.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Requirements

This shouldn't be merged until https://github.com/uselagoon/build-deploy-tool/pull/430 has been evaluated. The two are sort of linked together, merging this without the other just seems silly.