### PR TITLE
feat: extend deploymentsByFilter options

### DIFF
--- a/services/api/src/resources/deployment/resolvers.ts
+++ b/services/api/src/resources/deployment/resolvers.ts
@@ -190,14 +190,14 @@ export const getDeploymentsByFilter: ResolverFn = async (
   if (environmentType && !limitPerEnvironment) {
     // if environment type is set, assume only the latest deployment for the environment
     // is requested depending on the `deploymentStatus` options chosen
-    limitPerEnvironment = 1
+    limitPerEnvironment = 1;
   }
 
-  let limitedStatuses = ["complete", "failed", "cancelled"]
-  if (deploymentStatus.some(element => limitedStatuses.includes(element)) && !limitPerEnvironment) {
+  let limitedStatuses = ["complete", "failed", "cancelled"];
+  if (!limitPerEnvironment && deploymentStatus.some(element => limitedStatuses.includes(element))) {
     // if a user requests `complete`, `failed`, or `cancelled` status builds but does not include a `limitPerEnvironment` limit
     // set the limit to the last 5 deployments to limit the amount of returned data
-    limitPerEnvironment = 5
+    limitPerEnvironment = 5;
   }
   logger.info( Sql.selectDeploymentsByFilter(
     {
@@ -211,7 +211,7 @@ export const getDeploymentsByFilter: ResolverFn = async (
       limitPerEnvironment,
       limit
     }
-  ))
+  ));
   const rows = await query(sqlClientPool, Sql.selectDeploymentsByFilter(
     {
       startDate,
@@ -224,7 +224,7 @@ export const getDeploymentsByFilter: ResolverFn = async (
       limitPerEnvironment,
       limit
     }
-  ))
+  ));
 
   const withK8s = projectHelpers(sqlClientPool).aliasOpenshiftToK8s(rows);
   return withK8s;

--- a/services/api/src/resources/deployment/resolvers.ts
+++ b/services/api/src/resources/deployment/resolvers.ts
@@ -155,7 +155,16 @@ export const getDeploymentsByFilter: ResolverFn = async (
   { sqlClientPool, hasPermission, models, keycloakGrant, keycloakUsersGroups, adminScopes }
 ) => {
 
-  const { openshifts, deploymentStatus = ["NEW", "PENDING", "RUNNING", "QUEUED"], startDate, endDate, includeDeleted } = input;
+  let {
+    openshifts,
+    deploymentStatus = ["NEW", "PENDING", "RUNNING", "QUEUED"],
+    environmentType,
+    startDate,
+    endDate,
+    includeDeleted,
+    limitPerEnvironment,
+    limit
+  } = input;
 
   /*
     use the same mechanism for viewing all projects
@@ -178,39 +187,45 @@ export const getDeploymentsByFilter: ResolverFn = async (
     userProjectIds = getUserProjectIdsFromRoleProjectIds(userProjectRoles);
   }
 
-  let queryBuilder = knex.select("deployment.*").from('deployment').
-      join('environment', 'deployment.environment', '=', 'environment.id');
-
-  if (userProjectIds) {
-      queryBuilder = queryBuilder.whereIn('environment.project', userProjectIds);
+  if (environmentType && !limitPerEnvironment) {
+    // if environment type is set, assume only the latest deployment for the environment
+    // is requested depending on the `deploymentStatus` options chosen
+    limitPerEnvironment = 1
   }
 
-  // collect builds for a specific date range
-  if (startDate) {
-    queryBuilder = queryBuilder.where('deployment.created', '>=', input.startDate);
+  let limitedStatuses = ["complete", "failed", "cancelled"]
+  if (deploymentStatus.some(element => limitedStatuses.includes(element)) && !limitPerEnvironment) {
+    // if a user requests `complete`, `failed`, or `cancelled` status builds but does not include a `limitPerEnvironment` limit
+    // set the limit to the last 5 deployments to limit the amount of returned data
+    limitPerEnvironment = 5
   }
+  logger.info( Sql.selectDeploymentsByFilter(
+    {
+      startDate,
+      endDate,
+      environmentType,
+      userProjectIds,
+      deployTargets: openshifts,
+      deploymentStatus,
+      includeDeleted,
+      limitPerEnvironment,
+      limit
+    }
+  ))
+  const rows = await query(sqlClientPool, Sql.selectDeploymentsByFilter(
+    {
+      startDate,
+      endDate,
+      environmentType,
+      userProjectIds,
+      deployTargets: openshifts,
+      deploymentStatus,
+      includeDeleted,
+      limitPerEnvironment,
+      limit
+    }
+  ))
 
-  if (endDate) {
-    queryBuilder = queryBuilder.where('deployment.created', '<=', input.endDate);
-  }
-
-  if(openshifts) {
-    queryBuilder = queryBuilder.whereIn('environment.openshift', openshifts);
-  }
-
-  queryBuilder = queryBuilder.whereIn('deployment.status', deploymentStatus);
-
-  // if includeDeleted is false, exclude deleted environments in the results (default)
-  if (!includeDeleted) {
-    queryBuilder = queryBuilder.where('environment.deleted', '=', '0000-00-00 00:00:00');
-  }
-
-  // exclude results where a project doesn't exist
-  queryBuilder = queryBuilder.whereRaw('environment.project IN (SELECT id FROM project)')
-
-  const queryBuilderString = queryBuilder.toString();
-
-  const rows = await query(sqlClientPool, queryBuilderString);
   const withK8s = projectHelpers(sqlClientPool).aliasOpenshiftToK8s(rows);
   return withK8s;
 };

--- a/services/api/src/resources/deployment/sql.ts
+++ b/services/api/src/resources/deployment/sql.ts
@@ -207,8 +207,7 @@ export const Sql = {
         if (!includeDeleted) {
           queryBuilder = queryBuilder.where('environment.deleted', '=', '0000-00-00 00:00:00');
         }
-        queryBuilder = queryBuilder.whereRaw('environment.project IN (SELECT id FROM project)')
-        queryBuilder = queryBuilder.orderByRaw('deployment.created DESC, deployment.name DESC')
+        queryBuilder = queryBuilder.orderByRaw('deployment.created DESC, deployment.name DESC');
       })
   })
   .modify(function (queryBuilder) {

--- a/services/api/src/resources/deployment/sql.ts
+++ b/services/api/src/resources/deployment/sql.ts
@@ -152,4 +152,74 @@ export const Sql = {
       .where('environment', '=', environment)
       .delete()
       .toString(),
+  selectDeploymentsByFilter: ({
+    startDate,
+    endDate,
+    environmentType,
+    userProjectIds,
+    deployTargets,
+    deploymentStatus,
+    includeDeleted,
+    limitPerEnvironment,
+    limit,
+  }: {
+    startDate?: Date;
+    endDate?: Date;
+    environmentType: string;
+    userProjectIds?: number[];
+    deployTargets?: number[];
+    deploymentStatus?: string[];
+    includeDeleted?: boolean;
+    limitPerEnvironment?: number;
+    limit?: number;
+  }) =>
+  knex
+  .select('*')
+  .from(function() {
+    this.select(
+        'deployment.*',
+        'environment.project as project_id',
+        knex.raw('ROW_NUMBER() OVER (PARTITION BY deployment.environment ORDER BY deployment.created DESC) AS env_row_num'),
+      )
+      .from('deployment')
+      .innerJoin('environment', 'deployment.environment', 'environment.id')
+      .as('ranked_deployments')
+      .modify(function (queryBuilder) {
+        if (userProjectIds) {
+          queryBuilder = queryBuilder.whereIn('environment.project', userProjectIds);
+        }
+        // collect builds for a specific date range
+        if (startDate) {
+          queryBuilder = queryBuilder.where('deployment.created', '>=', startDate);
+        }
+        if (endDate) {
+          queryBuilder = queryBuilder.where('deployment.created', '<=', endDate);
+        }
+        // collect builds for specific environment type
+        if (environmentType) {
+          queryBuilder = queryBuilder.where('environment.environment_type', environmentType);
+        }
+        if(deployTargets) {
+          queryBuilder = queryBuilder.whereIn('environment.openshift', deployTargets);
+        }
+        queryBuilder = queryBuilder.whereIn('deployment.status', deploymentStatus);
+        // if includeDeleted is false, exclude deleted environments in the results (default)
+        if (!includeDeleted) {
+          queryBuilder = queryBuilder.where('environment.deleted', '=', '0000-00-00 00:00:00');
+        }
+        queryBuilder = queryBuilder.whereRaw('environment.project IN (SELECT id FROM project)')
+        queryBuilder = queryBuilder.orderByRaw('deployment.created DESC, deployment.name DESC')
+      })
+  })
+  .modify(function (queryBuilder) {
+    // limit the number of deployments per environment
+    if (limitPerEnvironment) {
+      queryBuilder = queryBuilder.where('env_row_num', '<=', limitPerEnvironment);
+    }
+    if (limit) {
+      queryBuilder = queryBuilder.limit(limit);
+    }
+    queryBuilder = queryBuilder.orderBy('created', 'desc')
+  })
+  .toString(),
 };

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -1692,7 +1692,16 @@ const typeDefs = gql`
     deploymentByRemoteId(id: String): Deployment
     deploymentByName(input: DeploymentByNameInput): Deployment
     deploymentsByBulkId(bulkId: String): [Deployment]
-    deploymentsByFilter(openshifts: [Int], deploymentStatus: [DeploymentStatusType], startDate: Date, endDate: Date, includeDeleted: Boolean): [Deployment]
+    deploymentsByFilter(
+      openshifts: [Int]
+      deploymentStatus: [DeploymentStatusType]
+      environmentType: EnvType
+      startDate: Date
+      endDate: Date
+      includeDeleted: Boolean
+      limitPerEnvironment: Int
+      limit: Int
+    ): [Deployment]
     taskByTaskName(taskName: String): Task
     taskByRemoteId(id: String): Task
     taskById(id: Int): Task


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

Adds some additional filtering options to the deploymentsByFilter query to be able to limit the number of deployments returned per environment or in total, and filter by environment type.

I set some arbitrary defaults for limits under certain conditions, this is to keep the current view in the `deployments` page in the UI to return the same information it currently does when there are no other changes to the filtering.

These limits are as follows
* If a user requests the `environmentType` filter, but does not provide a `limitPerEnvironment`, the limit is set to 1.
* If a user requests a status of `complete`, `failed`, or `cancelled`, then the `limitPerEnvironment` is set to 5.
In both cases, setting the `limitPerEnvironment` to a higher or lower value will override the default.

These combined with the existing status, start/end date, and deploytarget filters should offer more flexibility for users.

These filters could then be exposed on the all deployments overview page in the UI, allowing users to modify the filters to their liking.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

