### PR TITLE
chore: update twuni docker registry URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -693,6 +693,7 @@ helm/repos: local-dev/helm
 	$(HELM) repo add metallb https://metallb.github.io/metallb
 	$(HELM) repo add jetstack https://charts.jetstack.io
 	$(HELM) repo add jouve https://jouve.github.io/charts/
+	$(HELM) repo remove twuni
 	$(HELM) repo add twuni https://twuni.github.io/docker-registry.helm
 	$(HELM) repo add k8up https://k8up-io.github.io/k8up
 	$(HELM) repo add appuio https://charts.appuio.ch

--- a/Makefile
+++ b/Makefile
@@ -693,11 +693,12 @@ helm/repos: local-dev/helm
 	$(HELM) repo add metallb https://metallb.github.io/metallb
 	$(HELM) repo add jetstack https://charts.jetstack.io
 	$(HELM) repo add jouve https://jouve.github.io/charts/
-	$(HELM) repo remove twuni
-	$(HELM) repo add twuni https://twuni.github.io/docker-registry.helm
 	$(HELM) repo add k8up https://k8up-io.github.io/k8up
 	$(HELM) repo add appuio https://charts.appuio.ch
 	$(HELM) repo add prometheus-community https://prometheus-community.github.io/helm-charts
+ifeq ($(INSTALL_UNAUTHENTICATED_REGISTRY),true)
+	$(HELM) repo add twuni https://twuni.github.io/docker-registry.helm
+endif
 	$(HELM) repo update
 
 # stand up a k3d cluster configured appropriately for lagoon testing

--- a/Makefile
+++ b/Makefile
@@ -693,7 +693,7 @@ helm/repos: local-dev/helm
 	$(HELM) repo add metallb https://metallb.github.io/metallb
 	$(HELM) repo add jetstack https://charts.jetstack.io
 	$(HELM) repo add jouve https://jouve.github.io/charts/
-	$(HELM) repo add twuni https://helm.twun.io
+	$(HELM) repo add twuni https://twuni.github.io/docker-registry.helm
 	$(HELM) repo add k8up https://k8up-io.github.io/k8up
 	$(HELM) repo add appuio https://charts.appuio.ch
 	$(HELM) repo add prometheus-community https://prometheus-community.github.io/helm-charts


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

twuni changed where the helm repo lives, since this is only used for the unauthenticated registry, to prevent issues with this change in CI (where we aren't using the unauthenticated registry) simply don't install it.

Locally, users may have to run `helm repo remove twuni` to remove the old reference prior to running a local-stack, if using the unauthenticated registry option.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

closes #4011 
