### PR TITLE
fix: add delete_restore_permission function call in keycloak startup

### DIFF
--- a/services/keycloak/startup-scripts/00-configure-lagoon.sh
+++ b/services/keycloak/startup-scripts/00-configure-lagoon.sh
@@ -1148,6 +1148,7 @@ function configure_keycloak {
     add_lagoon-ui_impersonator_mappers
     add_lagoon-ui-oidc_impersonator_mappers
     add_route_permissions
+    delete_restore_permissions
 
     # always run last
     sync_client_secrets


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

#4028 forgot to add the call to run the migration for adding the delete restore permissions

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

