### PR TITLE
Fix: Allow for classic & beta-ui `clientId's` in password reset

### DIFF
--- a/services/api/src/models/user.ts
+++ b/services/api/src/models/user.ts
@@ -693,7 +693,7 @@ const getAllProjectsIdsForUser = async (
     if (resetPassword) {
       try {
         await passwordResetHandler(user.id);
-      } catch (err) {
+      } catch (err: any) {
         logger.warn(`Failed to send password reset email: ${err.message}`);
       }
     }
@@ -773,6 +773,7 @@ const getAllProjectsIdsForUser = async (
   const passwordResetHandler = async (id: string): Promise<void> => {
     const uiClientIDs = ["lagoon-ui", "lagoon-ui-oidc"];
     const redirectUri = getConfigFromEnv("UI_URL", "http://localhost:8888");
+    let error: unknown;
 
     for (const uiClientID of uiClientIDs) {
       try {
@@ -785,15 +786,16 @@ const getAllProjectsIdsForUser = async (
         });
         return;
       } catch (err) {
-        logger.warn(`Failed to send password reset email: ${err.message}`);
+        error = err;
       }
     }
+    throw error;
   };
 
   const resetUserPassword = async (id: string): Promise<void> => {
     try {
       await passwordResetHandler(id);
-    } catch (err) {
+    } catch (err: any) {
       if (err.response?.status === 404) {
         throw new UserNotFoundError(`User not found: ${id}`);
       }

--- a/services/api/src/models/user.ts
+++ b/services/api/src/models/user.ts
@@ -695,6 +695,7 @@ const getAllProjectsIdsForUser = async (
         await passwordResetHandler(user.id);
       } catch (err: any) {
         logger.warn(`Failed to send password reset email: ${err.message}`);
+        throw new Error(`Failed to send password reset email: ${err.message}`);
       }
     }
 
@@ -771,17 +772,17 @@ const getAllProjectsIdsForUser = async (
   }
 
   const passwordResetHandler = async (id: string): Promise<void> => {
-    const uiClientIDs = ["lagoon-ui", "lagoon-ui-oidc"];
+    const uiClientIds = ["lagoon-ui", "lagoon-ui-oidc"];
     const redirectUri = getConfigFromEnv("UI_URL", "http://localhost:8888");
     let error: unknown;
 
-    for (const uiClientID of uiClientIDs) {
+    for (const uiClientId of uiClientIds) {
       try {
         await keycloakAdminClient.users.executeActionsEmail({
           id,
           lifespan: 43200,
           actions: ["UPDATE_PASSWORD"],
-          clientId: uiClientID,
+          clientId: uiClientId,
           redirectUri
         });
         return;

--- a/services/api/src/models/user.ts
+++ b/services/api/src/models/user.ts
@@ -691,13 +691,11 @@ const getAllProjectsIdsForUser = async (
     }
 
     if (resetPassword) {
-      await keycloakAdminClient.users.executeActionsEmail({
-        id: user.id,
-        lifespan: 43200,
-        actions: ["UPDATE_PASSWORD"],
-        clientId: "lagoon-ui",
-        redirectUri: getConfigFromEnv('UI_URL', "http://localhost:8888")
-      });
+      try {
+        await passwordResetHandler(user.id);
+      } catch (err) {
+        logger.warn(`Failed to send password reset email: ${err.message}`);
+      }
     }
 
     // Let's start with the email opt-in preference defaults
@@ -772,21 +770,34 @@ const getAllProjectsIdsForUser = async (
     )(user);
   }
 
+  const passwordResetHandler = async (id: string): Promise<void> => {
+    const uiClientIDs = ["lagoon-ui", "lagoon-ui-oidc"];
+    const redirectUri = getConfigFromEnv("UI_URL", "http://localhost:8888");
+
+    for (const uiClientID of uiClientIDs) {
+      try {
+        await keycloakAdminClient.users.executeActionsEmail({
+          id,
+          lifespan: 43200,
+          actions: ["UPDATE_PASSWORD"],
+          clientId: uiClientID,
+          redirectUri
+        });
+        return;
+      } catch (err) {
+        logger.warn(`Failed to send password reset email: ${err.message}`);
+      }
+    }
+  };
+
   const resetUserPassword = async (id: string): Promise<void> => {
     try {
-      await keycloakAdminClient.users.executeActionsEmail({
-        id: id,
-        lifespan: 43200,
-        actions: ["UPDATE_PASSWORD"],
-        clientId: "lagoon-ui",
-        redirectUri: getConfigFromEnv('UI_URL', "http://localhost:8888")
-      });
+      await passwordResetHandler(id);
     } catch (err) {
-      if (err.response.status && err.response.status === 404) {
+      if (err.response?.status === 404) {
         throw new UserNotFoundError(`User not found: ${id}`);
-      } else {
-        throw new Error(`Error updating Lagoon user account: ${err.message}`);
       }
+      throw new Error(`Error updating Lagoon user account: ${err.message}`);
     }
   };
 


### PR DESCRIPTION
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Description

Updates the `resetUserPassword` logic to allows for either Keycloak UI client to be used (`classic/beta-ui`). Currently it's configured only for the classic client, resulting in password reset failures when using the beta-ui.
