### PR TITLE
fix: cleanup local-stack docker build artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1028,7 +1028,7 @@ k3d/get-lagoon-cli-details:
 .PHONY: k3d/seed-data
 k3d/seed-data: k3d/generate-user-keys
 	@export KUBECONFIG="$$(realpath ./kubeconfig.k3d.$(CI_BUILD_TAG))" && \
-	export LAGOON_LEGACY_ADMIN=$$(docker run \
+	export LAGOON_LEGACY_ADMIN=$$(docker run --rm \
 		-e JWTSECRET="$$($(KUBECTL) get secret -n lagoon-core lagoon-core-secrets -o jsonpath="{.data.JWTSECRET}" | base64 --decode)" \
 		-e JWTAUDIENCE=api.dev \
 		-e JWTUSER=localadmin \


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Database Migrations

n/a

# Description

Running `make k3d/local-stack` would leave stopped containers hanging around, this just cleans those up automatically.


<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

n/a
