### PR TITLE
Fixes missing detail in userByEmail() query

### DIFF
--- a/services/api/src/models/user.ts
+++ b/services/api/src/models/user.ts
@@ -364,11 +364,13 @@ export const User = (clients: {
   };
 
   const enrichUserWithPlatformRoles = async (user: User): Promise<User> => {
-      const roleMappings = await keycloakAdminClient.users.listRealmRoleMappings({ id: user.id });
+      const roleMappings = await keycloakAdminClient.users.listRealmRoleMappings({
+        id: user.id
+      });
       const validRoles = new Set(Object.values(PlatformRole));
       const platformRoles = roleMappings
-      .map(r => r.name)
-      .filter(name => validRoles.has(name)) as [string];
+        .map(r => r.name)
+        .filter((name): name is PlatformRole => validRoles.has(name as PlatformRole));
 
       return { ...user, platformRoles };
   };

--- a/services/api/src/models/user.ts
+++ b/services/api/src/models/user.ts
@@ -86,6 +86,7 @@ export interface UserModel {
   transformKeycloakUsers: (keycloakUsers: UserRepresentation[]) => Promise<User[]>;
   getFullUserDetails: (userInput: User) => Promise<Object>;
   fetchUserTwoFactor: (user: User) => Promise<boolean>;
+  enrichUserWithPlatformRoles: (user: User) => Promise<User>;
 }
 
 // these match the names of the roles created in keycloak
@@ -360,6 +361,16 @@ export const User = (clients: {
 
     // @ts-ignore
     return await loadUserById(userId);
+  };
+
+  const enrichUserWithPlatformRoles = async (user: User): Promise<User> => {
+      const roleMappings = await keycloakAdminClient.users.listRealmRoleMappings({ id: user.id });
+      const validRoles = new Set(Object.values(PlatformRole));
+      const platformRoles = roleMappings
+      .map(r => r.name)
+      .filter(name => validRoles.has(name)) as [string];
+
+      return { ...user, platformRoles };
   };
 
   const loadUserByIdOrEmail = async (userInput: UserEdit): Promise<User> => {
@@ -1041,5 +1052,6 @@ const getAllProjectsIdsForUser = async (
     transformKeycloakUsers,
     getFullUserDetails,
     fetchUserTwoFactor,
+    enrichUserWithPlatformRoles,
   };
 };

--- a/services/api/src/resources/user/resolvers.ts
+++ b/services/api/src/resources/user/resolvers.ts
@@ -115,7 +115,6 @@ export const getAllUsers: ResolverFn = async (
     });
     return filteredByGitlab;
   }
-
   return users;
 };
 
@@ -123,10 +122,10 @@ export const getAllUsers: ResolverFn = async (
 export const getUserByEmail: ResolverFn = async (
   _root,
   { email },
-  { sqlClientPool, models, hasPermission, keycloakGrant },
+  { sqlClientPool, models, hasPermission, keycloakGrant, adminScopes },
 ) => {
 
-  const user = await models.UserModel.loadUserByEmail(email);
+  let user = await models.UserModel.loadUserByEmail(email);
   if (keycloakGrant) {
     if (keycloakGrant.access_token.content.sub == user.id) {
       await hasPermission('ssh_key', 'view:user', {
@@ -137,6 +136,10 @@ export const getUserByEmail: ResolverFn = async (
     }
   } else {
     await hasPermission('user', 'viewAll');
+  }
+
+  if (adminScopes.platformOwner || adminScopes.platformViewer) {
+    user = await models.UserModel.enrichUserWithPlatformRoles(user);
   }
 
   return user;

--- a/services/api/src/resources/user/resolvers.ts
+++ b/services/api/src/resources/user/resolvers.ts
@@ -121,8 +121,9 @@ export const getAllUsers: ResolverFn = async (
 // query to get all users, with some inputs to limit the search to specific email, id, or gitlabId
 export const getUserByEmail: ResolverFn = async (
   _root,
-  { email },
+  { email},
   { sqlClientPool, models, hasPermission, keycloakGrant, adminScopes },
+  info
 ) => {
 
   let user = await models.UserModel.loadUserByEmail(email);
@@ -138,7 +139,8 @@ export const getUserByEmail: ResolverFn = async (
     await hasPermission('user', 'viewAll');
   }
 
-  if (adminScopes.platformOwner || adminScopes.platformViewer) {
+  const platformRoleRequested = info.fieldNodes[0].selectionSet.selections.find(item => item.name.value === "platformRoles");
+  if ( platformRoleRequested && (adminScopes.platformOwner || adminScopes.platformViewer)) {
     user = await models.UserModel.enrichUserWithPlatformRoles(user);
   }
 


### PR DESCRIPTION
This PR enhances the user model with a convenience function that lets one enrich a user object with the platform roles.
This is then used to plug a hole in the current "userByEmail()" query, which doesn't actually return platform roles.

The enrichment is gated by the same logic used by the allPlatformUsers query.
