### PR TITLE
chore: reduce log verbosity for core ssh service

### DIFF
--- a/services/ssh/Dockerfile
+++ b/services/ssh/Dockerfile
@@ -14,7 +14,8 @@ COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/
 COPY --from=commons /home /home
 
 RUN chmod g+w /etc/passwd \
-    && mkdir -p /home
+    && mkdir -p /home \
+    && touch /no_authorized_keys && chmod 444 /no_authorized_keys
 
 ENV TMPDIR=/tmp \
     TMP=/tmp \

--- a/services/ssh/etc/ssh/sshd_config
+++ b/services/ssh/etc/ssh/sshd_config
@@ -11,9 +11,8 @@ MaxAuthTries ${MAX_AUTH_TRIES:-6}
 
 PermitRootLogin no
 
-# The default is to check both .ssh/authorized_keys and .ssh/authorized_keys2
-# but this is overridden so installations will only check .ssh/authorized_keys
-AuthorizedKeysFile /dev/null
+# No static authorized keys, they are all handled via AuthorizedKeysCommand
+AuthorizedKeysFile /no_authorized_keys
 
 AuthorizedKeysCommand /authorize.sh %u %f
 AuthorizedKeysCommandUser lagoon


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Database Migrations

n/a

# Description

Every time an SSH key is authenticating to the core ssh service, a log like `User lagoon-demo-org-main authorized keys /dev/null is not a regular file` is printed. This PR just makes it so that goes away.

This reduces the amount of logs by ~16%.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

n/a
