### PR TITLE
chore: reduce log verbosity for backup-handler

### DIFF
--- a/services/backup-handler/internal/handler/main.go
+++ b/services/backup-handler/internal/handler/main.go
@@ -194,6 +194,8 @@ func (b *BackupHandler) WebhookHandler(w http.ResponseWriter, r *http.Request) {
 			for _, backup := range addBackups {
 				b.addToMessageQueue(backup)
 			}
+		} else if backupData.BackupMetrics.Folder != "" {
+			// Skip progess webhook
 		} else {
 			// if we get something that we don't know how to handle, spit out what it is so we can check it in the logs
 			backupJSON, err := json.Marshal(backupData)


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Database Migrations

n/a

# Description

k8up sends webhooks to the `backup-handler` for certain events, and there is a fallback that logs the webhook data if the webhook can't be handled. For every snapshot, k8up sends two webhooks: 1) a webhook with progress/metrics information about the single snapshot and 2) a webhook with a list of all snapshots.

Currently, scenario (1) results in a log being printed, and this PR adds a check to exclude it, since it is a webhook that is known to not be handled. This reduces logs by ~30%.

Example extraneous log (formatted for clarity):
```
unable to handle webhook, data is: {
    "name": "lagoon-demo-org-main",
    "bucket_name": "baas-lagoon-demo-org",
    "backup_metrics": {
        "backup_start_timestamp": 1,
        "backup_end_timestamp": 1773711035,
        "errors": 0,
        "new_files": 1,
        "changed_files": 0,
        "unmodified_files": 0,
        "new_dirs": 0,
        "changed_dirs": 0,
        "unmodified_dirs": 0,
        "data_transferred": 2624556,
        "mounted_PVCs": [],
        "Folder": "/lagoon-demo-org-main-mariadb-prebackuppod.mariadb.sql"
    },
    "snapshots": null,
    "restore_location": "",
    "snapshot_ID": "",
    "restored_files": null
}
```

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

n/a
