### PR TITLE
fix: advanced task environment argument shows deleted environments

### DIFF
--- a/services/api/src/resources/task/models/advancedTaskDefinitionArgument.ts
+++ b/services/api/src/resources/task/models/advancedTaskDefinitionArgument.ts
@@ -1,5 +1,4 @@
 import { query } from '../../../util/db';
-import * as R from 'ramda';
 
 export class ArgumentBase {
     async validateInput(input): Promise<boolean> {
@@ -38,11 +37,18 @@ export class EnvironmentSourceArgument extends ArgumentBase {
     }
 
     protected async loadEnvNames() {
-        const rows = await query(
-            this.sqlClientPool,
-            `select e.name as name from environment as e inner join environment as p on e.project = p.project where p.id = ${this.environmentId}`
+        const rows = await query(this.sqlClientPool,
+            `SELECT name
+            FROM environment
+            WHERE deleted = "0000-00-00 00:00:00"
+            AND project = (
+                SELECT project
+                FROM environment
+                WHERE id = :envid
+            )`,
+            { envid: this.environmentId }
           );
-        this.environmentNameList = R.pluck('name')(rows);
+        this.environmentNameList = rows.map(row => row.name);
     }
 
     /**
@@ -79,11 +85,19 @@ export class OtherEnvironmentSourceNamesArgument extends ArgumentBase {
     }
 
     protected async loadEnvNames() {
-        const rows = await query(
-            this.sqlClientPool,
-            `select e.name as name from environment as e inner join environment as p on e.project = p.project where p.id = ${this.environmentId} and e.id != ${this.environmentId}`
+        const rows = await query(this.sqlClientPool,
+            `SELECT name
+            FROM environment
+            WHERE deleted = "0000-00-00 00:00:00"
+            AND id != :envid
+            AND project = (
+                SELECT project
+                FROM environment
+                WHERE id = :envid
+            )`,
+            { envid: this.environmentId }
           );
-        this.environmentNameList = R.pluck('name')(rows);
+        this.environmentNameList = rows.map(row => row.name);
     }
 
     /**


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Database Migrations

n/a

# Description

When defining an advanced task argument of type `ENV_VAR_NAME_SOURCE` or `ENVIRONMENT_SOURCE_NAME_EXCLUDE_SELF`, the returned list of environments included deleted environments. This results in a list with potentially a lot of duplicated items.

<img height="500" alt="image" src="https://github.com/user-attachments/assets/a9ffabdc-48bb-4ff1-97a5-0eea68fa3040" />


Selecting any of the duplicates is valid, since the environment name is the most important part, but it can be confusing. This PR filters out deleted environments, since there isn't ever a reason to be able to select one.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

n/a
