### PR TITLE
Fixes expiry and iat logic for legacy tokens

### DIFF
--- a/services/api/src/util/auth.ts
+++ b/services/api/src/util/auth.ts
@@ -127,7 +127,7 @@ export const getCredentialsForLegacyToken = async (token: string): Promise<Legac
 
     // First check if the iat is _before_ now, with some tolerance for clock drift
     if (iat > (nowSeconds + clockSkew)) {
-      const msg = `Legacy token (sub:${sub}; iss:${iss}) iat ${(iat)} is issued before ${nowDate}`;
+      const msg = `Legacy token (sub:${sub}; iss:${iss}) iat ${(iat)} is issued before ${nowSeconds}`;
       throw new Error(msg);
     }
 

--- a/services/api/src/util/auth.ts
+++ b/services/api/src/util/auth.ts
@@ -119,7 +119,18 @@ export const getCredentialsForLegacyToken = async (token: string): Promise<Legac
   // check the expiration on legacy tokens, reject them if necessary
   const maxExpiry = getConfigFromEnv('LEGACY_EXPIRY_MAX', '3600') // 1hour default
   const rejectLegacyExpiry = getConfigFromEnv('LEGACY_EXPIRY_REJECT', 'false') // don't reject intially, just log
+  // Give some tolerance to the calculations around `iat` below
+  const clockSkew = parseInt(getConfigFromEnv('LEGACY_TOKEN_CLOCK_SKEW_TOLERANCE_SECONDS', '60'));
+  const nowDate = Date.now();
+  const nowSeconds = Math.floor(nowDate / 1000);
   if (exp && iat) {
+
+    // First check if the iat is _before_ now, with some tolerance for clock drift
+    if (iat > (nowSeconds + clockSkew)) {
+      const msg = `Legacy token (sub:${sub}; iss:${iss}) iat ${(iat)} is issued before ${nowDate}`;
+      throw new Error(msg);
+    }
+
     if ((exp-iat) > parseInt(maxExpiry)) {
       const msg = `Legacy token (sub:${sub}; iss:${iss}) expiry ${(exp-iat)} is greater than ${parseInt(maxExpiry)}`
       logger.warn(msg);


### PR DESCRIPTION
As the expiry logic for the legacy token stands, it doesn't actually protect from someone having a _practically_ long lived token if they set the distance between `exp` and `iat` to be below the current tolerance BUT set them to be arbitrarily far in the future.

Currently we only test 
1. that the time between `exp` and `iat` meets the tolerance
2. that the token hasn't expired (taken care of by the library validation)

What this introduces is, within some tolerance, that the `iat` is before the present moment