### PR TITLE
Update Broker to RabbitMQ version 4.1.8

### DIFF
--- a/services/broker/Dockerfile
+++ b/services/broker/Dockerfile
@@ -1,7 +1,7 @@
 ARG UPSTREAM_REPO
 ARG UPSTREAM_TAG
 FROM ${UPSTREAM_REPO:-uselagoon}/commons:${UPSTREAM_TAG:-latest} AS commons
-FROM rabbitmq:4.1.0-management-alpine
+FROM rabbitmq:4.1.8-management-alpine
 
 ARG LAGOON_VERSION
 ENV LAGOON_VERSION=$LAGOON_VERSION


### PR DESCRIPTION
This pull request updates the base image version for RabbitMQ in the `services/broker/Dockerfile` to improve stability and security.

Dependency update:

* Updated the RabbitMQ base image from `rabbitmq:4.1.0-management-alpine` to `rabbitmq:4.1.8-management-alpine` in `services/broker/Dockerfile`.

