### PR TITLE
Upgrade Keycloak to version 26.4.7 and custom protocol mapper to 1.1.1

### DIFF
--- a/services/keycloak/Dockerfile
+++ b/services/keycloak/Dockerfile
@@ -1,5 +1,5 @@
 # Stage: Build the custom token mapper
-FROM maven:3.9.9-eclipse-temurin-21-alpine as builder
+FROM maven:3.9.14-eclipse-temurin-21-alpine as builder
 COPY custom-mapper/. .
 RUN mvn clean compile package
 
@@ -20,7 +20,7 @@ COPY javascript /tmp/lagoon-scripts
 RUN cd /tmp/lagoon-scripts && zip -r ../lagoon-scripts.jar *
 
 # Stage: Build the keycloak image
-FROM quay.io/keycloak/keycloak:26.3.1
+FROM quay.io/keycloak/keycloak:26.4.7
 COPY --from=ubi-micro-build /mnt/rootfs /
 
 ARG LAGOON_VERSION
@@ -97,7 +97,7 @@ COPY startup-scripts /opt/keycloak/startup-scripts
 COPY themes/lagoon /opt/keycloak/themes/lagoon
 COPY themes/lagoon-v2 /opt/keycloak/themes/lagoon-v2
 COPY --from=commons /tmp/lagoon-scripts.jar /opt/keycloak/providers/lagoon-scripts.jar
-COPY --from=builder /target/custom-protocol-mapper-1.1.0.jar /opt/keycloak/providers/custom-protocol-mapper-1.1.0.jar
+COPY --from=builder /target/custom-protocol-mapper-1.1.1.jar /opt/keycloak/providers/custom-protocol-mapper-1.1.1.jar
 
 COPY lagoon-realm-base-import.json /lagoon/seed/lagoon-realm-base-import.json
 

--- a/services/keycloak/custom-mapper/pom.xml
+++ b/services/keycloak/custom-mapper/pom.xml
@@ -6,11 +6,11 @@
 
     <groupId>net.cake.keycloak.custom</groupId>
     <artifactId>custom-protocol-mapper</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <packaging>jar</packaging>
 
     <properties>
-        <keycloak.version>26.3.1</keycloak.version>
+        <keycloak.version>26.4.7</keycloak.version>
     </properties>
 
     <dependencies>
@@ -58,6 +58,19 @@
                     <source>1.8</source>
                     <target>1.8</target>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>io.smallrye</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <version>3.2.2</version>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This pull request updates the Keycloak service and its custom protocol mapper to use newer versions, and introduces a new Maven plugin to the build process. The main goals are to keep dependencies up to date and improve build tooling.

**Dependency and version updates:**

* Upgraded the Keycloak Docker base image from `26.3.1` to `26.4.7` in `services/keycloak/Dockerfile`, and updated the Keycloak dependency version in `custom-mapper/pom.xml` to match. [[1]](diffhunk://#diff-a73572d2bf8ca702584a1173ce50d2ddce884c4ade3736de21549c437b02f836L23-R23) [[2]](diffhunk://#diff-baffeabe06e1f61d41c64815ab31aad7e9b66337c6dc2815a6839bdf3e4b433eL9-R13)
* Updated the Maven builder image from `maven:3.9.9-eclipse-temurin-21-alpine` to `maven:3.9.14-eclipse-temurin-21-alpine` in `services/keycloak/Dockerfile`.
* Bumped the `custom-protocol-mapper` version from `1.1.0` to `1.1.1` in both the artifact and the Dockerfile copy step. [[1]](diffhunk://#diff-baffeabe06e1f61d41c64815ab31aad7e9b66337c6dc2815a6839bdf3e4b433eL9-R13) [[2]](diffhunk://#diff-a73572d2bf8ca702584a1173ce50d2ddce884c4ade3736de21549c437b02f836L100-R100)

**Build process improvements:**

* Added the `jandex-maven-plugin` (version `3.2.2`) to `custom-mapper/pom.xml` to generate Jandex indexes during the build, which can improve runtime performance for some Java frameworks.

