### PR TITLE
feat: support latest pushed for harbor retention policies

### DIFF
--- a/services/api/src/resources/retentionpolicy/PAYLOADS.md
+++ b/services/api/src/resources/retentionpolicy/PAYLOADS.md
@@ -32,12 +32,14 @@ And the decoded `miscResource` payload is structured like this, based on the typ
                 {
                     "name": "all branches, excluding pullrequests",
                     "pattern": "[^pr\\-]*/*",
-                    "latestPulled": 3
+                    "latestPulled": 3,
+                    "latestPushed": 3
                 },
                 {
                     "name": "pullrequests",
                     "pattern": "pr-*",
-                    "latestPulled": 1
+                    "latestPulled": 1,
+                    "latestPushed": 1
                 }
             ],
             "schedule": "3 3 * * 3"

--- a/services/api/src/resources/retentionpolicy/types.ts
+++ b/services/api/src/resources/retentionpolicy/types.ts
@@ -9,6 +9,7 @@ export interface HarborRetentionRule {
     name: string
     pattern: string
     latestPulled: number
+    latestPushed: number
 }
 
 export interface HistoryRetentionPolicy {
@@ -71,6 +72,9 @@ export const RetentionPolicy = () => {
             }
             if (typeof rule.latestPulled != "number") {
                 throw new Error(`${rule.name}: latestPulled must be a number`);
+            }
+            if (typeof rule.latestPushed != "number") {
+                throw new Error(`${rule.name}: latestPushed must be a number`);
             }
         }
         if (typeof c.schedule != "string") {

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -2779,6 +2779,7 @@ const typeDefs = gql`
     """
     pattern: String
     latestPulled: Int
+    latestPushed: Int
   }
 
   """
@@ -2869,6 +2870,7 @@ const typeDefs = gql`
     name: String!
     pattern: String!
     latestPulled: Int!
+    latestPushed: Int
   }
 
   """


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

This extends the harbor retention policy support to include the optional `latestPushed` value. This can be used to ensure that the last `N` pushed images are not pruned by the retention policy to ensure that in the event that the retention policy happens mid phase of a build, that the recently pushed images are no not immediately pruned due to not having been pulled yet.

Requires https://github.com/uselagoon/remote-controller/pull/369
