### PR TITLE
Improve mkcert fallback handling in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -806,8 +806,8 @@ k3d/checkout-charts: k3d/generate-ca
 		&& cd "$$CHARTSDIR" \
 		&& git checkout $(CHARTS_TREEISH) \
 		&& mkdir -p certs \
-		&& CAROOT="$$(mkcert -CAROOT)" \
-		&& test -f "$$CAROOT/rootCA.pem" && cp "$$CAROOT"/* certs/. || cp ../local-dev/certificates/* certs/.
+		&& CAROOT="$$(command -v mkcert > /dev/null 2>&1 && mkcert -CAROOT || true)" \
+		&& test -n "$$CAROOT" && test -f "$$CAROOT/rootCA.pem" && cp "$$CAROOT"/* certs/. || cp ../local-dev/certificates/* certs/.
 
 # this just installs lagoon-core, lagoon-remote, and lagoon-build-deploy
 # doing this allows for lagoon to be installed with a known stable chart version with the INSTALL_STABLE_X overrides


### PR DESCRIPTION
Enhance the handling of mkcert in the Makefile to ensure a fallback mechanism is in place when mkcert is not available. This change addresses potential issues with certificate generation by checking for mkcert's existence before attempting to use it.

