### PR TITLE
chore: update docs to prefer lagoon CLI for ssh commands

### DIFF
--- a/docs/interacting/graphql.md
+++ b/docs/interacting/graphql.md
@@ -4,16 +4,10 @@
 
 API interactions in Lagoon are done via GraphQL. In order to authenticate to the API, you need a JWT (JSON Web Token), which will authenticate you against the API via your SSH public key.
 
-To generate this token, use the remote shell via the `token` command:
+To generate this token, use the [Lagoon CLI](https://uselagoon.github.io/lagoon-cli/)'s `get token` command:
 
 ```bash title="Get token"
-ssh -p [PORT] -t lagoon@[HOST] token
-```
-
-{{ defaults.name }} connection string:
-
-```bash title="Get {{ defaults.name }} token"
-ssh -p {{ defaults.sshport }} -t lagoon@{{ defaults.sshhostname }} token
+lagoon get token
 ```
 
 This will return a long string, which is the JWT token.

--- a/docs/interacting/ssh.md
+++ b/docs/interacting/ssh.md
@@ -54,34 +54,50 @@ A general example of using the Lagoon API via GraphQL to add an SSH key to a use
 
 ## SSH into a pod
 
-!!! Note
-    The easiest way to SSH into a pod is to use the [Lagoon CLI](https://github.com/uselagoon/lagoon-cli).
+The recommended way to SSH into a pod is to use the [Lagoon CLI](https://uselagoon.github.io/lagoon-cli/).
+The `lagoon ssh` command automatically queries the Lagoon API to determine the optimal SSH endpoint to connect to, and takes care of setting the relevant SSH options.
 
-    The instructions below only apply if you want to use the regular `ssh` client, or other advanced use cases.
-
-### Connection
-
-Connecting is straightforward and follows the following pattern:
-
-```bash title="SSH"
-ssh {% if defaults.sshport != 22 %}-p [PORT] {% endif %}[PROJECT-ENVIRONMENT-NAME]@[HOST]
+```bash title="Lagoon CLI SSH"
+lagoon ssh -p [PROJECT-NAME] -e [ENVIRONMENT-NAME]
 ```
 
-* `HOST` - The remote shell SSH endpoint host (for example `{{ defaults.sshhostname }}`).
-* `PROJECT-ENVIRONMENT-NAME` - The environment you want to connect to. This is most commonly in the pattern `PROJECTNAME-ENVIRONMENT`.
-
-As an example:
-
-```bash title="SSH example"
-ssh {% if defaults.sshport != 22 %}-p {{ defaults.sshport }} {% endif %}drupal-example-main@{{ defaults.sshhostname }}
-```
-
-This will connect you to a `cli` pod in the environment `main` of the project `drupal-example`.
+You can find more details in the [Lagoon CLI SSH documentation](https://uselagoon.github.io/lagoon-cli/commands/lagoon_ssh/).
 
 ### Pod/Service, Container Definition
 
 By default the remote shell will try to connect you to the first container in the pod of the service type `cli`.
-If you would like to connect to another service you can specify it using a `service=[SERVICE-NAME]` argument to the SSH command.
+If you would like to connect to another service you can specify it using the `-s` argument to the Lagoon CLI command.
+
+```bash title="SSH to another service example"
+lagoon ssh -p [PROJECT-NAME] -e [ENVIRONMENT-NAME] -s [SERVICE-NAME]
+```
+
+If your pod/service contains multiple containers, Lagoon will connect you to the first defined container. You can also define the specific container to connect to via the `-c` argument:
+
+```bash title="Define container"
+lagoon ssh -p [PROJECT-NAME] -e [ENVIRONMENT-NAME] -s [SERVICE-NAME] -c [CONTAINER-NAME]
+```
+
+For example, to connect to the `php` container within the `nginx` pod:
+
+```bash title="SSH to php container"
+lagoon ssh -p drupal-example -e main -s nginx -c php
+```
+
+## Copying files and advanced SSH usage
+
+For advanced use cases like copying files using tools such as `scp` or `rsync` where the Lagoon CLI's capabilities may not directly apply, you will need the underlying raw `ssh` connection details. 
+
+You can get the required `ssh` command and connection string by adding the `--conn-string` flag to your `lagoon ssh` command:
+
+```bash title="Get SSH connection string"
+lagoon ssh -p [PROJECT-NAME] -e [ENVIRONMENT-NAME] --conn-string
+```
+
+This command should return a connection string, for example: `ssh -t -p 32222 projectname-environment@ssh.lagoon.example.com`
+
+You can then use these details with the usual SSH-compatible tools.
+
 
 !!! Note
     When you run the [`ssh` client](https://man7.org/linux/man-pages/man1/ssh.1.html) command with just a `USER@HOST` argument, it will assume that you want an interactive session and allocate a [pty](https://www.man7.org/linux/man-pages/man7/pty.7.html).
@@ -89,54 +105,34 @@ If you would like to connect to another service you can specify it using a `serv
 
     However, when you provide an argument to the `ssh` client command, it assumes that you want a non-interactive session (e.g. just run a command and return) and will not allocate a pty.
 
-    **So when providing an argument such as `service=[SERVICE-NAME]`, if you want an interactive shell session you need to tell the `ssh` client to not "auto-detect" if it needs a pty and just allocate one anyway using the `-t` flag.**
-
-```bash title="SSH to another service example"
-ssh {% if defaults.sshport != 22 %}-p [PORT] {% endif %}-t [PROJECT-ENVIRONMENT-NAME]@[HOST] service=[SERVICE-NAME]
-```
-
-If your pod/service contains multiple containers, Lagoon will connect you to the first defined container. You can also define the specific container to connect to via:
-
-```bash title="Define container"
-ssh {% if defaults.sshport != 22 %}-p [PORT] {% endif %}-t [PROJECT-ENVIRONMENT-NAME]@[HOST] service=[SERVICE-NAME] container=[CONTAINER-NAME]
-```
-
-For example, to connect to the `php` container within the `nginx` pod:
-
-```bash title="SSH to php container"
-ssh {% if defaults.sshport != 22 %}-p {{ defaults.sshport }} {% endif %}-t drupal-example-main@{{ defaults.sshhostname }} service=nginx container=php
-```
-
-## Copying files
-
-The common case of copying a file into your `cli` pod can be achieved with the usual SSH-compatible tools.
+    So when providing an argument such as `service=[SERVICE-NAME]` to an `ssh` command that **you expect to give you an interactive shell** , you need to tell the `ssh` client to not "auto-detect" if it needs a pty and just allocate one anyway using the `-t` flag.
 
 ### scp
 
 ```bash title="Copy file with scp"
-scp {% if defaults.sshport != 22 %}-P {{ defaults.sshport }} {% endif %}[local_path] [project_name]-[environment_name]@{{ defaults.sshhostname }}:[remote_path]
+scp -P [PORT] [local_path] [project_name]-[environment_name]@[HOST]:[remote_path]
 ```
 
 ### rsync
 
 ```bash title="Copy files with rsync"
-rsync {% if defaults.sshport != 22 %}--rsh='ssh -p {{ defaults.sshport }}'{% else %}--rsh=ssh{% endif %} [local_path] [project_name]-[environment_name]@{{ defaults.sshhostname }}:[remote_path]
+rsync --rsh='ssh -p [PORT]' [local_path] [project_name]-[environment_name]@[HOST]:[remote_path]
 ```
 
 ### tar
 
 ```bash
-ssh {% if defaults.sshport != 22 %}-p {{ defaults.sshport }} {% endif %}[project_name]-[environment_name]@{{ defaults.sshhostname }} tar -zcf - [remote_path] | tar -zxf - -C /tmp/
+ssh -p [PORT] [project_name]-[environment_name]@[HOST] tar -zcf - [remote_path] | tar -zxf - -C /tmp/
 ```
 
-### Specifying non-CLI pod/service
+### Specifying non-CLI pod/service for file copying
 
-In the rare case that you need to specify a non-CLI service you can specify the `service=...` and/or `container=...` arguments in the copy command.
+In the case that you need to specify a non-CLI service as a file copy source/target, you can append `service=...` and/or `container=...` arguments to the SSH connection string provided by the `--conn-string` flag.
 
 Piping `tar` through the `ssh` connection is the simplest method, and can be used to copy a file or directory using the usual `tar` flags:
 
 ```bash
-ssh {% if defaults.sshport != 22 %}-p {{ defaults.sshport }} {% endif %}[project_name]-[environment_name]@{{ defaults.sshhostname }} service=solr tar -zcf - [remote_path] | tar -zxf - -C /tmp/
+ssh -p [PORT] [project_name]-[environment_name]@[HOST] service=solr tar -zcf - [remote_path] | tar -zxf - -C /tmp/
 ```
 
 You can also use `rsync` with a wrapper script to reorder the arguments to `ssh` in the manner required by Lagoon's SSH service:
@@ -145,13 +141,13 @@ You can also use `rsync` with a wrapper script to reorder the arguments to `ssh`
 #!/usr/bin/env sh
 svc=$1 user=$3 host=$4
 shift 4
-exec ssh {% if defaults.sshport != 22 %}-p {{ defaults.sshport }} {% endif %}-l "$user" "$host" "$svc" "$@"
+exec ssh -p [PORT] -l "$user" "$host" "$svc" "$@"
 ```
 
 Put that in an executable shell script `rsh.sh` and specify the `service=...` in the `rsync` command:
 
 ```bash title="rsync to non-CLI pod"
-rsync --rsh="/path/to/rsh.sh service=cli" /tmp/foo [project_name]-[environment_name]@{{ defaults.sshhostname }}:/tmp/foo
+rsync --rsh="/path/to/rsh.sh service=cli" /tmp/foo [project_name]-[environment_name]@[HOST]:/tmp/foo
 ```
 
 The script could also be adjusted to also handle a `container=...` argument.

--- a/docs/interacting/ssh.md
+++ b/docs/interacting/ssh.md
@@ -101,11 +101,11 @@ You can then use these details with the usual SSH-compatible tools.
 
 !!! Note
     When you run the [`ssh` client](https://man7.org/linux/man-pages/man1/ssh.1.html) command with just a `USER@HOST` argument, it will assume that you want an interactive session and allocate a [pty](https://www.man7.org/linux/man-pages/man7/pty.7.html).
-    This give you a regular shell environment where you can enter commands at a prompt, send interrupts using `^C` etc.
+    This gives you a regular shell environment where you can enter commands at a prompt, send interrupts using `^C` etc.
 
     However, when you provide an argument to the `ssh` client command, it assumes that you want a non-interactive session (e.g. just run a command and return) and will not allocate a pty.
 
-    So when providing an argument such as `service=[SERVICE-NAME]` to an `ssh` command that **you expect to give you an interactive shell** , you need to tell the `ssh` client to not "auto-detect" if it needs a pty and just allocate one anyway using the `-t` flag.
+    So when providing an argument such as `service=[SERVICE-NAME]` to an `ssh` command that **you expect to give you an interactive shell**, you need to tell the `ssh` client to not "auto-detect" if it needs a pty and just allocate one anyway using the `-t` flag.
 
 ### scp
 

--- a/docs/resources/faq.md
+++ b/docs/resources/faq.md
@@ -123,13 +123,15 @@ Once you've added a runtime environment variable to your production environment 
 
 ## How do I SFTP files to/from my Lagoon environment?
 
-For cloud hosting customers, you can SFTP to your Lagoon environment by using the following information:
+For cloud hosting customers, you can SFTP to your Lagoon environment by using the connection string details provided by the Lagoon CLI.
 
-* Server Hostname: `{{ defaults.sshhostname }}`
-* Port: {{ defaults.sshport }}
-* Username: &lt;Project-Environment-Name&gt;
+Run the following command to get your SSH connection details:
 
-Your username is going to be the name of the environment you are connecting to, most commonly in the pattern _`PROJECTNAME-ENVIRONMENT`_.
+```bash title="Get SSH connection string"
+lagoon ssh -p [PROJECT-NAME] -e [ENVIRONMENT-NAME] --conn-string
+```
+
+This will return the SSH connection string, which contains the user, host, and port needed for your SFTP client.
 
 You may also be interested in checking out our new Lagoon Sync tool, which you can read about here: [https://github.com/uselagoon/lagoon-sync](https://github.com/uselagoon/lagoon-sync)
 

--- a/docs/resources/faq.md
+++ b/docs/resources/faq.md
@@ -131,7 +131,7 @@ Run the following command to get your SSH connection details:
 lagoon ssh -p [PROJECT-NAME] -e [ENVIRONMENT-NAME] --conn-string
 ```
 
-This will return the SSH connection string, which contains the user, host, and port needed for your SFTP client.
+This will return an `ssh ...` connection string; use the user/host/port values from that output in your SFTP client configuration.
 
 You may also be interested in checking out our new Lagoon Sync tool, which you can read about here: [https://github.com/uselagoon/lagoon-sync](https://github.com/uselagoon/lagoon-sync)
 


### PR DESCRIPTION
# General Checklist

- [ ] ~Affected Issues have been mentioned in the Closing issues section~
- [x] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] ~If your PR contains a database migation, it **MUST** be the latest in date order alphabetically~ n/a

# Description

This updates the documentation to prefer using `lagoon ssh` instead of raw `ssh` commands to interact with Lagoon.

The Lagoon CLI commands are much harder to get wrong and take care of using ssh portal if possible.

# Closing issues

None, but this PR updates one of the pages mentioned in #4060. Future work would be merging those two pages.