### PR TITLE
docs: tidy rbac page and include fact permissions in matrix

### DIFF
--- a/docs/interacting/rbac.md
+++ b/docs/interacting/rbac.md
@@ -1,10 +1,16 @@
 # Role-Based Access Control \(RBAC\)
 
-Version 1.0 of Lagoon changed how you access your projects! Access to your project is handled via groups, with projects assigned to one or multiple groups. Users are added to groups with a role. Groups can also be nested within sub-groups. This change provides a lot more flexibility and the possibility to recreate real world teams within Lagoon.
+Version 1.0 of Lagoon changed how you access your projects! 
+Access to your project is handled via groups, with projects assigned to one or multiple groups. 
+Users are added to groups with a role. 
+Groups can also be nested within sub-groups. 
+This change provides a lot more flexibility and the possibility to recreate real world teams within Lagoon.
 
 ## Roles
 
-When assigning a user to a group, you need to provide a group role for that user inside this group. Each one of the 5 current existing group roles gives the user different permissions to the group and projects assigned to the group. Here are the platform-wide roles and the group roles that are currently found in Lagoon:
+When assigning a user to a group, you need to provide a group role for that user inside this group. 
+Each one of the 5 current existing group roles gives the user different permissions to the group and projects assigned to the group. 
+Here are the platform-wide roles and the group roles that are currently found in Lagoon:
 
 ### Platform-Wide Roles
 
@@ -20,63 +26,81 @@ Similar to the platform-wide owner, except this role can only view.
 
 #### Platform-Wide Organization Owner
 
-The platform-wide organization owner role provides permission to create, update, delete, and all other permissions related to changes within an organization, including existing organizations. It does not grant full platform-wide owner access, this means the ability to access and deploy projects still needs to be granted via a group within an organization.
+The Platform-Wide Organization Owner role provides permission to create, update, delete, and all other permissions related to changes within an organization, including existing organizations. 
+It does not grant full platform-wide owner access, this means the ability to access and deploy projects still needs to be granted via a group within an organization.
 
-This role also has the ability to view all the deploytargets (kubernetes clusters) assigned to Lagoon so that they can be assigned to an organization when it is being created.
+This role also has the ability to view all the `deploytargets` (kubernetes clusters) assigned to Lagoon so that they can be assigned to an organization when it is being created.
 
 !!! Warning "NOTE"
-    By default this role does not allow the creation of environments or the ability to trigger deployments within a project within an organization. They can add themselves to a group with a role that does grant them this permission.
+    By default this role does not allow the creation of environments or the ability to trigger deployments within a project within an organization. 
+    They can add themselves to a group with a role that does grant them this permission.
 
 ### Organization Roles
 
 #### Organization Owner
 
-The organization owner role allows for the creation and deletion of projects, groups, and notifications within their organization.
+The Organization Owner role allows for the creation and deletion of projects, groups, and notifications within their organization.
 
-They can add users to groups, change the roles of users within those groups, and associate projects with groups. This gives the organization owner the ability to clearly see who has access, and quickly add and remove users.
+They can add users to groups, change the roles of users within those groups, and associate projects with groups. 
+This gives the Organization Owner the ability to clearly see who has access, and quickly add and remove users.
 
-Organization owners now also have the ability to create Slack or other notifications directly, and associate those notifications with a project without requiring help from {{ defaults.helpstring }}.
+Organization Owners now also have the ability to create Slack or other notifications directly, and associate those notifications with a project without requiring help from {{ defaults.helpstring }}.
 
-Organization owners also have the ability to add and remove other owners, admins, or viewers to manage their organization.
+Organization Owners also have the ability to add and remove other Organization Owners, Organization Admins, or Organization Viewers.
 
 !!! Warning "NOTE"
-    By default this role does not allow organization owners to create environments or trigger deployments within a project. They can add themselves to a group with a role that does grant them this permission. When creating a project, an organization owner can opt to be added as an owner of the project default group.
+    By default this role does not allow Organization Owners to create environments or trigger deployments within a project. 
+    They can add themselves to a group with a role that does grant them this permission. 
+    When creating a project, an Organization Owner can opt to be added as an owner of the project default group.
 
 #### Organization Admin
 
-The organization admin role is the same as organization owner, except that this role cannot make changes to the owners, admins, or viewers of the organization.
+The Organization Admin role is the same as the Organization Owner, except that this role cannot make changes to the Organization Owners, Organization Admins, or Organization Viewers.
 
 #### Organization Viewer
 
-The organization view has access to view the projects, group and user access, and notifications within their organization.
+The Organization Viewer has access to view the projects, group and user access, and notifications within their organization.
 
 ### Group Roles
 
 #### Owner
 
-The owner role can do everything within a group and its associated projects. They can add and manage users of a group. Be careful with this role, as it can delete projects and production environments!
+The Owner role can do everything within a group and its associated projects. 
+They can add and manage users of a group. 
+Be careful with this role, as it can delete projects and production environments!
 
 !!! Danger "IMPORTANT"
-    If a user has this role in a group that is within the scope of an organization, this role's ability to manage that group's users is removed. Only organization owners or admins can manage groups and their users.
+    If a user has this role in a group that is within the scope of an organization, this role's ability to manage that group's users is removed. 
+    Only organization owners or admins can manage groups and their users.
 
 #### Maintainer
 
-The maintainer role can do everything within a group and its associated projects except deleting the project itself or the production environment. They can add and manage users of a group.
+The Maintainer role can do everything within a group and its associated projects except deleting the project itself or the production environment. 
+They can add and manage users of a group.
 
 #### Developer
 
-The developer role has SSH access only to development environments. This role cannot access, update or delete the production environment. They can run a sync task with the production environment as a source, but not as the destination. Cannot manage users of a group.
+The Developer role has SSH access only to development environments. 
+They cannot access, update or delete the production environment. 
+They can run a sync task with the production environment as a source, but not as the destination. 
+They can view, add, and delete Facts associated with an environment.
+They can manage [custom tasks](/using-lagoon-advanced/custom-tasks/), set or delete Environment environment variables, and view notifications set for a project.
+They cannot manage the users of a group.
 
 !!! Danger "IMPORTANT"
-    This role does not prevent the deployment of the production environment as a deployment is triggered via a Git push! You need to make sure that your Git server prevents these users from pushing into the branch defined as production environment.
+    This role does not prevent the deployment of the production environment as a deployment is triggered via a Git push! 
+    You need to make sure that your Git server prevents these users from pushing into the branch defined as production environment.
 
 #### Reporter
 
-The reporter role has view access only. They cannot access any environments via SSH or make modifications to them. They can run cache-clear tasks. This role is mostly used for stakeholders to have access to Lagoon UI and logging.
+The Reporter role has view access only. 
+They cannot access any environments via SSH or make modifications to them. 
+They can run cache-clear tasks. 
+This role is mostly used for stakeholders to have access to Lagoon UI and logging.
 
 #### Guest
 
-The guest role has the same privileges as the reporter role listed above.
+The Guest role has the same privileges as the reporter role listed above.
 
 Here is a table that lists the roles and the access they have:
 
@@ -125,6 +149,9 @@ Here is a table that lists the roles and the access they have:
 
     | **Name** | **Resource** | **Scope** | **Attributes** |
     | :--- | :--- | :--- | :--- |
+    | addFact | fact | add | environmentID |
+    | deleteFact | fact | delete | environmentID |
+    | getFactsByEnvironmentID | fact | view | environmentID |
     | addBackup | backup | add | projectID |
     | getBackupsByEnvironmentId | backup | view | projectID |
     | addEnvVariable \(to Environment\) | env\_var | environment:add:development | projectID |


### PR DESCRIPTION
# General Checklist

- [x] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Description

This PR updates the RBAC documentation with some changes I felt were beneficial:

- include some of the fact-related endpoints in the RBAC matrix (addFact, deleteFact, getFactByEnvironmentID)
- capitalise role names since these are defined terms, which I believe is a good stylistic choice
- place each new sentence of body text on a new line, improving editor quality-of-life when using line-based text editors such as vim without altering the presented formatting (markdown ignores line-ending newlines)