### PR TITLE
fix: validate organization group project associations

### DIFF
--- a/services/api/src/resources/organization/organization.test.ts
+++ b/services/api/src/resources/organization/organization.test.ts
@@ -1,0 +1,103 @@
+import { getGroupProjectOrganizationAssociation } from './resolvers';
+import { Helpers as organizationHelpers } from './helpers';
+import { Helpers as groupHelpers } from '../group/helpers';
+import { Helpers as projectHelpers } from '../project/helpers';
+
+jest.mock('../../clients/pubSub', () => ({
+  EVENTS: {
+    ORGPROJECT: 'api.subscription.orgproject',
+  },
+  createOrganizationFilteredSubscriber: jest.fn(() => ({})),
+}));
+
+jest.mock('./helpers', () => ({
+  Helpers: jest.fn(),
+}));
+
+jest.mock('../group/helpers', () => ({
+  Helpers: jest.fn(),
+}));
+
+jest.mock('../project/helpers', () => ({
+  Helpers: jest.fn(),
+}));
+
+describe('Organization resolvers', () => {
+  describe('getGroupProjectOrganizationAssociation', () => {
+    const sqlClientPool = {} as any;
+    const group = {
+      id: 'group-id',
+      name: 'group-name',
+    };
+    const input = {
+      organization: 1,
+      id: group.id,
+    };
+    const hasPermission = jest.fn();
+    const loadGroupByIdOrName = jest.fn();
+
+    const runResolver = () =>
+      getGroupProjectOrganizationAssociation(null, { input }, {
+        sqlClientPool,
+        hasPermission,
+        models: {
+          GroupModel: {
+            loadGroupByIdOrName,
+          },
+        },
+      } as any);
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      hasPermission.mockResolvedValue(undefined);
+      loadGroupByIdOrName.mockResolvedValue(group);
+      (organizationHelpers as jest.Mock).mockReturnValue({
+        getOrganizationById: jest
+          .fn()
+          .mockResolvedValue({ id: input.organization }),
+      });
+      (groupHelpers as jest.Mock).mockReturnValue({
+        selectProjectIdsByGroupID: jest.fn().mockResolvedValue([]),
+      });
+      (projectHelpers as jest.Mock).mockReturnValue({
+        getProjectByOrganizationId: jest.fn().mockResolvedValue([]),
+      });
+    });
+
+    it('rejects a group with projects when the target organization has no projects', async () => {
+      (groupHelpers as jest.Mock).mockReturnValue({
+        selectProjectIdsByGroupID: jest.fn().mockResolvedValue([101]),
+      });
+
+      await expect(runResolver()).rejects.toThrow(
+        'This organization has no projects associated to it, the following projects are not part of the requested organization: [101]',
+      );
+    });
+
+    it('rejects a group with projects outside a non-empty target organization', async () => {
+      (groupHelpers as jest.Mock).mockReturnValue({
+        selectProjectIdsByGroupID: jest.fn().mockResolvedValue([101, 202]),
+      });
+      (projectHelpers as jest.Mock).mockReturnValue({
+        getProjectByOrganizationId: jest.fn().mockResolvedValue([{ id: 101 }]),
+      });
+
+      await expect(runResolver()).rejects.toThrow(
+        'This group has the following projects that are not part of the requested organization: [202]',
+      );
+    });
+
+    it('allows a group whose projects are all in the target organization', async () => {
+      (groupHelpers as jest.Mock).mockReturnValue({
+        selectProjectIdsByGroupID: jest.fn().mockResolvedValue([101, 202]),
+      });
+      (projectHelpers as jest.Mock).mockReturnValue({
+        getProjectByOrganizationId: jest
+          .fn()
+          .mockResolvedValue([{ id: 101 }, { id: 202 }]),
+      });
+
+      await expect(runResolver()).resolves.toEqual('success');
+    });
+  });
+});

--- a/services/api/src/resources/organization/resolvers.ts
+++ b/services/api/src/resources/organization/resolvers.ts
@@ -971,16 +971,13 @@ const checkOrgProjectGroup = async (sqlClientPool, input, models) => {
     }
   }
 
-  if (projectIdsByOrg.length > 0 && groupProjectIds.length > 0) {
-    if (projectIdsByOrg.length == 0) {
-      let filters = arrayDiff(groupProjectIds, projectIdsByOrg)
-      throw new Error(`This organization has no projects associated to it, the following projects that are not part of the requested organization: [${filters}]`)
-    } else {
-      if (groupProjectIds.length > 0) {
-        let filters = arrayDiff(groupProjectIds, projectIdsByOrg)
-        if (filters.length > 0) {
-          throw new Error(`This group has the following projects that are not part of the requested organization: [${filters}]`)
-        }
+  if (groupProjectIds.length > 0) {
+    let filters = arrayDiff(groupProjectIds, projectIdsByOrg)
+    if (filters.length > 0) {
+      if (projectIdsByOrg.length == 0) {
+        throw new Error(`This organization has no projects associated to it, the following projects are not part of the requested organization: [${filters}]`)
+      } else {
+        throw new Error(`This group has the following projects that are not part of the requested organization: [${filters}]`)
       }
     }
   }


### PR DESCRIPTION
<!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated, or is not required for this bug fix
- [x] PR title is ready for inclusion in changelog

# Database Migrations

- [x] This PR does not contain a database migration

# Description

`checkOrgProjectGroup` only compared a group's project IDs against the target organization's project IDs when the organization already had at least one project. That made the empty-organization error branch unreachable and allowed `getGroupProjectOrganizationAssociation` / `addExistingGroupToOrganization` to accept a group that already referenced projects outside the requested organization.

This updates the validation to run whenever the group has project associations. Groups are now rejected when any associated project is not part of the target organization, including the case where the target organization has no projects. A focused resolver test covers the empty organization rejection, the non-empty organization mismatch, and the matching-project success case.

Validation performed:

- `yarn --cwd node-packages/commons build`
- `yarn --cwd services/api jest --forceExit --detectOpenHandles organization.test.ts`
- `yarn --cwd services/api build`
- `./node_modules/.bin/prettier --check services/api/src/resources/organization/organization.test.ts`
- `git diff --check`

I also ran `yarn --cwd services/api jest --forceExit --detectOpenHandles`; the new organization test passes, but the broader local suite still fails on unrelated existing issues: stale SQL snapshots in notification/environment tests, missing `src/resources/sshKey/index`, and a `node-fetch` ESM parse failure through `advancedtasktoolbox`.

# Closing issues

Closes #4081
