### PR TITLE
Explicitly sets and ups yarn install for workspace builder

### DIFF
--- a/yarn-workspace-builder/Dockerfile
+++ b/yarn-workspace-builder/Dockerfile
@@ -13,6 +13,6 @@ COPY services/auth-server/package.json /app/services/auth-server/
 COPY services/webhook-handler/package.json /app/services/webhook-handler/
 COPY services/webhooks2tasks/package.json /app/services/webhooks2tasks/
 
-RUN yarn install --frozen-lockfile
+RUN yarn install --frozen-lockfile  --network-timeout 300000
 
 RUN cd /app/node-packages/commons && yarn build


### PR DESCRIPTION
Arm builds are failing because of network timeout issues. This ups the timeout on yarn itself.



<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

Explain the **details** for making this change. What existing problem does the pull request solve?

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
