### PR TITLE
fix: variable only deployments named wrong for branch/pullrequest/promote

### DIFF
--- a/services/api/src/resources/deployment/helpers.ts
+++ b/services/api/src/resources/deployment/helpers.ts
@@ -5,6 +5,11 @@ import { query } from '../../util/db';
 import { Sql } from './sql';
 import { Helpers as environmentHelpers } from '../environment/helpers';
 
+interface EnvKeyValueInput {
+  name: string
+  value: string
+}
+
 export const Helpers = (sqlClientPool: Pool) => {
   const getDeploymentById = async (deploymentID: number) => {
     const rows = await query(
@@ -97,6 +102,15 @@ export const Helpers = (sqlClientPool: Pool) => {
         ]
       // @ts-ignore
       ])(deploymentInput);
+    },
+    isVariableOnlyDeployment: (buildVars: (EnvKeyValueInput | null)[] | null | undefined): boolean => {
+      if (!Array.isArray(buildVars)) {
+        return false
+      }
+
+      return buildVars.some(({name, value}) =>
+        name.toUpperCase() === 'LAGOON_VARIABLES_ONLY' && value.toUpperCase() === "TRUE"
+      )
     }
   };
 };

--- a/services/api/src/resources/deployment/resolvers.ts
+++ b/services/api/src/resources/deployment/resolvers.ts
@@ -799,12 +799,13 @@ export const deployEnvironmentLatest: ResolverFn = async (
     }
   }
 
-  let buildName = generateBuildId();
-  let buildType = DeploymentBuildType.BUILD
-  // change the buildname to a variables only name if the build variable for lagoon variables only is found
-  if (buildVariables && buildVariables.find(e => e.name === 'LAGOON_VARIABLES_ONLY' && e.value === "true")) {
+  let buildName: string, buildType: DeploymentBuildType
+  if (Helpers(sqlClientPool).isVariableOnlyDeployment(buildVariables)) {
     buildName = generateVariableOnlyBuildId();
     buildType = DeploymentBuildType.VARIABLES
+  } else {
+    buildName = generateBuildId();
+    buildType = DeploymentBuildType.BUILD
   }
 
   const sourceUser = await Helpers(sqlClientPool).getSourceUser(keycloakGrant, legacyGrant)
@@ -854,7 +855,8 @@ export const deployEnvironmentLatest: ResolverFn = async (
         headSha: `origin/${environment.deployHeadRef}`,
         baseBranchName: environment.deployBaseRef,
         baseSha: `origin/${environment.deployBaseRef}`,
-        branchName: environment.name
+        branchName: environment.name,
+        buildType
       };
       meta = {
         ...meta,
@@ -881,7 +883,8 @@ export const deployEnvironmentLatest: ResolverFn = async (
         sourceType: DeploymentSourceType.API,
         sourceUser: sourceUser,
         branchName: environment.name,
-        promoteSourceEnvironment: environment.deployBaseRef
+        promoteSourceEnvironment: environment.deployBaseRef,
+        buildType
       };
       meta = {
         ...meta,
@@ -998,7 +1001,15 @@ export const deployEnvironmentBranch: ResolverFn = async (
 };
 
 export async function deployBranch(returnData, project, branchName, branchRef, priority, bulkId, bulkName, buildVariables, sqlClientPool, keycloakGrant, legacyGrant, userActivityLogger, deploySourceType = DeploymentSourceType.API) {
-  let buildName = generateBuildId();
+  let buildName: string, buildType: DeploymentBuildType
+  if (Helpers(sqlClientPool).isVariableOnlyDeployment(buildVariables)) {
+    buildName = generateVariableOnlyBuildId();
+    buildType = DeploymentBuildType.VARIABLES
+  } else {
+    buildName = generateBuildId();
+    buildType = DeploymentBuildType.BUILD
+  }
+
   const sourceUser = await Helpers(sqlClientPool).getSourceUser(keycloakGrant, legacyGrant)
 
   const deployData = {
@@ -1012,7 +1023,8 @@ export async function deployBranch(returnData, project, branchName, branchRef, p
     bulkName: bulkName,
     buildVariables: buildVariables,
     sourceType: deploySourceType,
-    sourceUser: sourceUser
+    sourceUser: sourceUser,
+    buildType
   };
 
   const meta = {
@@ -1124,7 +1136,14 @@ export const deployEnvironmentPullrequest: ResolverFn = async (
   // check if project has restriction
   await projectHelpers(sqlClientPool).hasProjectRestriction('no_deployments', project.id, adminScopes)
 
-  let buildName = generateBuildId();
+  let buildName: string, buildType: DeploymentBuildType
+  if (Helpers(sqlClientPool).isVariableOnlyDeployment(buildVariables)) {
+    buildName = generateVariableOnlyBuildId();
+    buildType = DeploymentBuildType.VARIABLES
+  } else {
+    buildName = generateBuildId();
+    buildType = DeploymentBuildType.BUILD
+  }
 
   const sourceUser = await Helpers(sqlClientPool).getSourceUser(keycloakGrant, legacyGrant)
   const deployData = {
@@ -1143,7 +1162,8 @@ export const deployEnvironmentPullrequest: ResolverFn = async (
     bulkName: bulkName,
     buildVariables: buildVariables,
     sourceType: DeploymentSourceType.API,
-    sourceUser: sourceUser
+    sourceUser: sourceUser,
+    buildType
   };
 
   const meta = {
@@ -1270,7 +1290,14 @@ export const deployEnvironmentPromote: ResolverFn = async (
     project: sourceEnvironment.project
   });
 
-  let buildName = generateBuildId();
+  let buildName: string, buildType: DeploymentBuildType
+  if (Helpers(sqlClientPool).isVariableOnlyDeployment(buildVariables)) {
+    buildName = generateVariableOnlyBuildId();
+    buildType = DeploymentBuildType.VARIABLES
+  } else {
+    buildName = generateBuildId();
+    buildType = DeploymentBuildType.BUILD
+  }
 
   const sourceUser = await Helpers(sqlClientPool).getSourceUser(keycloakGrant, legacyGrant)
   const deployData = {
@@ -1284,7 +1311,8 @@ export const deployEnvironmentPromote: ResolverFn = async (
     bulkName: bulkName,
     buildVariables: buildVariables,
     sourceType: DeploymentSourceType.API,
-    sourceUser: sourceUser
+    sourceUser: sourceUser,
+    buildType
   };
 
   const meta = {


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Database Migrations

n/a

# Description

In https://github.com/uselagoon/lagoon/pull/4027, variable only deployments are indicated by a different deployment name and build type, but only when triggering the "latest" mutation.

The `build-deploy-tool` will run a variable only deployment regardless if it's `latest`, `branch`, `pullrequest`, or `promote`. This PR makes variable only deployments have different names and build types regardless of the deployment method.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

n/a
