### PR TITLE
Fixes range for testing k8s python lib

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
 ansible-core == 2.18.6
-kubernetes >= 31.0.0
+kubernetes >= 31.0.0, < 36.0.0
 jmespath == 1.0.1
 PyJWT == 2.9.0


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

The ansible tests are breaking in a way that is explained by https://github.com/kubernetes-client/python/issues/2582

This PR pulls us back from the latest version of the library

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

