### PR TITLE
feat: handle multiple env vars, add/update multiple, delete multiple

### DIFF
--- a/services/api/src/resolvers.js
+++ b/services/api/src/resolvers.js
@@ -353,6 +353,8 @@ const {
   deleteEnvVariable,
   addOrUpdateEnvVariableByName,
   deleteEnvVariableByName,
+  addOrUpdateEnvVariablesByName,
+  deleteEnvVariablesByName,
   getEnvVariablesByProjectEnvironmentName,
 } = require('./resources/env-variables/resolvers');
 
@@ -929,6 +931,8 @@ async function getResolvers() {
     deleteEnvVariable,
     addOrUpdateEnvVariableByName,
     deleteEnvVariableByName,
+    addOrUpdateEnvVariablesByName,
+    deleteEnvVariablesByName,
     addTask,
     addAdvancedTaskDefinition,
     updateAdvancedTaskDefinition,

--- a/services/api/src/resources/env-variables/resolvers.ts
+++ b/services/api/src/resources/env-variables/resolvers.ts
@@ -984,21 +984,26 @@ const deleteEnvVarRowByNameForTarget = async (
   target: EnvVarBatchTarget,
   name: string,
 ) => {
+  const trimmedName = (name || '').trim();
+  if (trimmedName.length === 0) {
+    throw new Error('A variable name must be provided.');
+  }
+
   let rows: any[] = [];
   if (target.envVarType === EnvVarType.ORGANIZATION) {
     rows = await query(
       sqlClientPool,
-      Sql.selectEnvVarByNameAndOrgId(name, target.organizationId),
+      Sql.selectEnvVarByNameAndOrgId(trimmedName, target.organizationId),
     );
   } else if (target.envVarType === EnvVarType.PROJECT) {
     rows = await query(
       sqlClientPool,
-      Sql.selectEnvVarByNameAndProjectId(name, target.projectId),
+      Sql.selectEnvVarByNameAndProjectId(trimmedName, target.projectId),
     );
   } else if (target.envVarType === EnvVarType.ENVIRONMENT) {
     rows = await query(
       sqlClientPool,
-      Sql.selectEnvVarByNameAndEnvironmentId(name, target.environmentId),
+      Sql.selectEnvVarByNameAndEnvironmentId(trimmedName, target.environmentId),
     );
   }
 

--- a/services/api/src/resources/env-variables/resolvers.ts
+++ b/services/api/src/resources/env-variables/resolvers.ts
@@ -8,6 +8,7 @@ import { Helpers as orgHelpers } from '../organization/helpers';
 import { AuditType } from '@lagoon/commons/dist/types';
 import { AuditLog, AuditResource } from '../audit/types';
 import {logger} from "../../loggers/logger";
+import { envVarsConfig } from '../../util/config';
 
 export enum EnvVarType {
   ORGANIZATION = 'organization',
@@ -780,4 +781,407 @@ export const deleteEnvVariable: ResolverFn = async (
   });
 
   return 'success';
+};
+
+// ---------------------------------------------------------------------------
+// Batch env variable resolvers
+//
+// These mutations operate on multiple variables for a single target
+// (organization, project, or environment). They share the same target
+// resolution / permission / project-restriction checks as the singular
+// resolvers above, but those checks fail-fast for the whole batch. Per-entry
+// errors (validation, DB constraint, etc.) are caught and reported back via
+// EnvVariableBatchResult, so a partial failure is observable to the caller.
+// ---------------------------------------------------------------------------
+
+type EnvVarBatchTarget = {
+  envVarType: EnvVarType;
+  envVarTypeName: string;
+  resource: AuditResource;
+  orgId?: number;
+  // Exactly one of these is populated based on envVarType:
+  organizationId?: number;
+  projectId?: number;
+  environmentId?: number;
+};
+
+type EnvVarBatchEntryResult = {
+  name: string;
+  success: boolean;
+  envVariable: any | null;
+  error: string | null;
+};
+
+type EnvVarBatchResult = {
+  successCount: number;
+  failureCount: number;
+  results: EnvVarBatchEntryResult[];
+};
+
+// Resolves the (single) target of a batch env-var operation and runs the
+// corresponding hasPermission and hasProjectRestriction checks. Throws on
+// any whole-batch failure (target not found, permission denied, restriction
+// violation, invalid target combo).
+const resolveEnvVarBatchTarget = async (
+  input: { organization?: string; project?: string; environment?: string },
+  action: 'add' | 'delete',
+  ctx: { sqlClientPool: any; hasPermission: any; adminScopes: any },
+): Promise<EnvVarBatchTarget> => {
+  const { sqlClientPool, hasPermission, adminScopes } = ctx;
+  const { organization: orgName, project: projectName, environment: environmentName } = input;
+
+  const envVarType = getEnvVarType({
+    organization: orgName,
+    project: projectName,
+    environment: environmentName,
+  });
+
+  if (envVarType instanceof Error) {
+    throw envVarType;
+  }
+
+  if (envVarType === EnvVarType.ORGANIZATION) {
+    const org = await orgHelpers(sqlClientPool).getOrganizationByName(orgName);
+    if (!org) {
+      throw new Error(`Organization '${orgName}' not found`);
+    }
+    await hasPermission(
+      'organization',
+      action === 'add' ? 'addEnvVar' : 'deleteEnvVar',
+      { organization: org.id },
+    );
+    return {
+      envVarType,
+      envVarTypeName: orgName,
+      resource: {
+        id: org.id.toString(),
+        type: AuditType.ORGANIZATION,
+        details: org.name,
+      },
+      orgId: org.id,
+      organizationId: org.id,
+    };
+  }
+
+  // PROJECT or ENVIRONMENT — both need the project resolved first.
+  const project = await projectHelpers(sqlClientPool).getProjectByProjectInput({
+    name: projectName,
+  });
+  if (!project) {
+    throw new Error(`Project '${projectName}' not found`);
+  }
+
+  if (envVarType === EnvVarType.PROJECT) {
+    await hasPermission(
+      'env_var',
+      action === 'add' ? 'project:add' : 'project:delete',
+      { project: project.id },
+    );
+    await projectHelpers(sqlClientPool).hasProjectRestriction(
+      'no_project_variables',
+      project.id,
+      adminScopes,
+    );
+    return {
+      envVarType,
+      envVarTypeName: projectName,
+      resource: {
+        id: project.id.toString(),
+        type: AuditType.PROJECT,
+        details: project.name,
+      },
+      orgId: project.organization || undefined,
+      projectId: project.id,
+    };
+  }
+
+  // ENVIRONMENT
+  const environmentRows = await query(
+    sqlClientPool,
+    Sql.selectEnvironmentByNameAndProject(environmentName, project.id),
+  );
+  const environment = environmentRows[0];
+  if (!environment) {
+    // For parity with the singular delete resolver: fall back to a project
+    // permission check so we don't leak environment existence to callers
+    // who can't see the project.
+    await hasPermission('project', 'view', { project: project.id });
+    throw new Error(`environment ${environmentName} doesn't exist`);
+  }
+  await hasPermission(
+    'env_var',
+    action === 'add'
+      ? `environment:add:${environment.environmentType}`
+      : `environment:delete:${environment.environmentType}`,
+    { project: project.id },
+  );
+  await projectHelpers(sqlClientPool).hasProjectRestriction(
+    'no_environment_variables',
+    project.id,
+    adminScopes,
+  );
+  return {
+    envVarType,
+    envVarTypeName: environmentName,
+    resource: {
+      id: environment.id.toString(),
+      type: AuditType.ENVIRONMENT,
+      details: environment.name,
+    },
+    orgId: project.organization || undefined,
+    projectId: project.id,
+    environmentId: environment.id,
+  };
+};
+
+// Upserts a single env var row for an already-resolved target. Mirrors the
+// behavior of addOrUpdateEnvVariableByName but takes a pre-resolved target
+// so we can loop without re-resolving for each entry.
+const upsertEnvVarRowForTarget = async (
+  sqlClientPool: any,
+  target: EnvVarBatchTarget,
+  entry: { name: string; value: string; scope?: string },
+) => {
+  if (!entry.name || entry.name.trim().length === 0) {
+    throw new Error('A variable name must be provided.');
+  }
+  if (entry.scope === 'internal_container_registry') {
+    throw new Error(
+      'Variable scope "internal_container_registry" is deprecated & can no longer be set.',
+    );
+  }
+
+  const updateData: any = {
+    name: entry.name.trim(),
+    value: entry.value,
+    scope: entry.scope,
+    updated: knex.fn.now(),
+  };
+
+  if (target.envVarType === EnvVarType.ORGANIZATION) {
+    updateData.organization = target.organizationId;
+  } else if (target.envVarType === EnvVarType.PROJECT) {
+    updateData.project = target.projectId;
+  } else if (target.envVarType === EnvVarType.ENVIRONMENT) {
+    updateData.environment = target.environmentId;
+  }
+
+  const createOrUpdateSql = knex('env_vars')
+    .insert({ ...updateData })
+    .onConflict('id')
+    .merge({ ...updateData })
+    .toString();
+
+  const { insertId } = await query(sqlClientPool, createOrUpdateSql);
+  const rows = await query(sqlClientPool, Sql.selectEnvVariable(insertId));
+  return R.prop(0, rows);
+};
+
+// Looks up an env var by name within an already-resolved target and deletes
+// it. Idempotent: if the row doesn't exist, returns null without throwing.
+const deleteEnvVarRowByNameForTarget = async (
+  sqlClientPool: any,
+  target: EnvVarBatchTarget,
+  name: string,
+) => {
+  let rows: any[] = [];
+  if (target.envVarType === EnvVarType.ORGANIZATION) {
+    rows = await query(
+      sqlClientPool,
+      Sql.selectEnvVarByNameAndOrgId(name, target.organizationId),
+    );
+  } else if (target.envVarType === EnvVarType.PROJECT) {
+    rows = await query(
+      sqlClientPool,
+      Sql.selectEnvVarByNameAndProjectId(name, target.projectId),
+    );
+  } else if (target.envVarType === EnvVarType.ENVIRONMENT) {
+    rows = await query(
+      sqlClientPool,
+      Sql.selectEnvVarByNameAndEnvironmentId(name, target.environmentId),
+    );
+  }
+
+  const row = rows[0];
+  if (!row) {
+    return null; // idempotent
+  }
+  await query(sqlClientPool, Sql.deleteEnvVariable(row.id));
+  return row;
+};
+
+const enforceBatchSize = (size: number, fieldName: string) => {
+  if (size === 0) {
+    throw new Error(`'${fieldName}' must contain at least one entry.`);
+  }
+  if (size > envVarsConfig.batchLimit) {
+    throw new Error(
+      `Batch size ${size} exceeds the maximum of ${envVarsConfig.batchLimit}. ` +
+        `Split your request into smaller batches.`,
+    );
+    // TODO: When request exceeds BATCH_ENV_VARS_LIMIT, server-side chunking
+    // could iterate the batch in fixed-size groups and combine results into
+    // a single EnvVariableBatchResult. For now we reject oversize batches
+    // and require the client to split. See uselagoon/lagoon#4092.
+  }
+};
+
+export const addOrUpdateEnvVariablesByName: ResolverFn = async (
+  root,
+  {
+    input: {
+      project: projectName,
+      environment: environmentName,
+      organization: orgName,
+      variables,
+    },
+  },
+  { sqlClientPool, hasPermission, userActivityLogger, adminScopes },
+): Promise<EnvVarBatchResult> => {
+  enforceBatchSize(variables ? variables.length : 0, 'variables');
+
+  const target = await resolveEnvVarBatchTarget(
+    { organization: orgName, project: projectName, environment: environmentName },
+    'add',
+    { sqlClientPool, hasPermission, adminScopes },
+  );
+
+  const results: EnvVarBatchEntryResult[] = [];
+  for (const entry of variables) {
+    try {
+      const row = await upsertEnvVarRowForTarget(sqlClientPool, target, entry);
+      results.push({
+        name: entry.name,
+        success: true,
+        envVariable: row,
+        error: null,
+      });
+    } catch (err) {
+      logger.warn(
+        `Batch upsert env var '${entry.name}' failed for ${target.envVarType} ` +
+          `'${target.envVarTypeName}': ${err.message}`,
+      );
+      results.push({
+        name: entry.name,
+        success: false,
+        envVariable: null,
+        error: err.message,
+      });
+    }
+  }
+
+  const successCount = results.filter(r => r.success).length;
+  const failureCount = results.length - successCount;
+
+  const auditLog: AuditLog = {
+    resource: target.resource,
+    linkedResource: {
+      id: target.resource.id,
+      type: AuditType.VARIABLE,
+      details:
+        `batch addOrUpdate: scope=${target.envVarType} ` +
+        `count=${results.length} success=${successCount} failure=${failureCount} ` +
+        `names=[${variables.map(v => v.name).join(',')}]`,
+    },
+  };
+  if (target.orgId) {
+    auditLog.organizationId = target.orgId;
+  }
+  userActivityLogger(
+    `User batch added/updated environment variables on ${target.envVarType} '${target.envVarTypeName}'`,
+    {
+      project: projectName,
+      event: 'api:addOrUpdateEnvVariablesByName',
+      payload: {
+        envVarType: target.envVarType,
+        envVarTypeName: target.envVarTypeName,
+        count: results.length,
+        successCount,
+        failureCount,
+        ...auditLog,
+      },
+    },
+  );
+
+  return { successCount, failureCount, results };
+};
+
+export const deleteEnvVariablesByName: ResolverFn = async (
+  root,
+  {
+    input: {
+      project: projectName,
+      environment: environmentName,
+      organization: orgName,
+      names,
+    },
+  },
+  { sqlClientPool, hasPermission, userActivityLogger, adminScopes },
+): Promise<EnvVarBatchResult> => {
+  enforceBatchSize(names ? names.length : 0, 'names');
+
+  const target = await resolveEnvVarBatchTarget(
+    { organization: orgName, project: projectName, environment: environmentName },
+    'delete',
+    { sqlClientPool, hasPermission, adminScopes },
+  );
+
+  const results: EnvVarBatchEntryResult[] = [];
+  for (const name of names) {
+    try {
+      await deleteEnvVarRowByNameForTarget(sqlClientPool, target, name);
+      results.push({
+        name,
+        success: true,
+        envVariable: null,
+        error: null,
+      });
+    } catch (err) {
+      logger.warn(
+        `Batch delete env var '${name}' failed for ${target.envVarType} ` +
+          `'${target.envVarTypeName}': ${err.message}`,
+      );
+      results.push({
+        name,
+        success: false,
+        envVariable: null,
+        error: err.message,
+      });
+    }
+  }
+
+  const successCount = results.filter(r => r.success).length;
+  const failureCount = results.length - successCount;
+
+  const auditLog: AuditLog = {
+    resource: target.resource,
+    linkedResource: {
+      id: target.resource.id,
+      type: AuditType.VARIABLE,
+      details:
+        `batch delete: scope=${target.envVarType} ` +
+        `count=${results.length} success=${successCount} failure=${failureCount} ` +
+        `names=[${names.join(',')}]`,
+    },
+  };
+  if (target.orgId) {
+    auditLog.organizationId = target.orgId;
+  }
+  userActivityLogger(
+    `User batch deleted environment variables on ${target.envVarType} '${target.envVarTypeName}'`,
+    {
+      project: projectName,
+      event: 'api:deleteEnvVariablesByName',
+      payload: {
+        envVarType: target.envVarType,
+        envVarTypeName: target.envVarTypeName,
+        count: results.length,
+        successCount,
+        failureCount,
+        ...auditLog,
+      },
+    },
+  );
+
+  return { successCount, failureCount, results };
 };

--- a/services/api/src/resources/env-variables/resolvers.ts
+++ b/services/api/src/resources/env-variables/resolvers.ts
@@ -1160,7 +1160,6 @@ export const deleteEnvVariablesByName: ResolverFn = async (
   const auditLog: AuditLog = {
     resource: target.resource,
     linkedResource: {
-      id: target.resource.id,
       type: AuditType.VARIABLE,
       details:
         `batch delete: scope=${target.envVarType} ` +

--- a/services/api/src/resources/env-variables/resolvers.ts
+++ b/services/api/src/resources/env-variables/resolvers.ts
@@ -1076,7 +1076,6 @@ export const addOrUpdateEnvVariablesByName: ResolverFn = async (
   const auditLog: AuditLog = {
     resource: target.resource,
     linkedResource: {
-      id: target.resource.id,
       type: AuditType.VARIABLE,
       details:
         `batch addOrUpdate: scope=${target.envVarType} ` +

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -1095,6 +1095,19 @@ const typeDefs = gql`
     updated: String
   }
 
+  type EnvVariableBatchEntryResult {
+    name: String!
+    success: Boolean!
+    envVariable: EnvKeyValue
+    error: String
+  }
+
+  type EnvVariableBatchResult {
+    successCount: Int!
+    failureCount: Int!
+    results: [EnvVariableBatchEntryResult!]!
+  }
+
   type Task {
     id: Int
     name: String
@@ -2730,6 +2743,26 @@ const typeDefs = gql`
     environment: String
   }
 
+  input EnvVariableEntryInput {
+    name: String!
+    value: String!
+    scope: EnvVariableScope
+  }
+
+  input EnvVariablesByNameInput {
+    organization: String
+    project: String
+    environment: String
+    variables: [EnvVariableEntryInput!]!
+  }
+
+  input DeleteEnvVariablesByNameInput {
+    organization: String
+    project: String
+    environment: String
+    names: [String!]!
+  }
+
   input SetEnvironmentServicesInput {
     environment: Int!
     services: [String]!
@@ -3211,6 +3244,8 @@ const typeDefs = gql`
     deleteEnvVariable(input: DeleteEnvVariableInput!): String  @deprecated(reason: "Use deleteEnvVariableByName instead")
     addOrUpdateEnvVariableByName(input: EnvVariableByNameInput!): EnvKeyValue
     deleteEnvVariableByName(input: DeleteEnvVariableByNameInput!): String
+    addOrUpdateEnvVariablesByName(input: EnvVariablesByNameInput!): EnvVariableBatchResult!
+    deleteEnvVariablesByName(input: DeleteEnvVariablesByNameInput!): EnvVariableBatchResult!
     addTask(input: TaskInput!): Task
     addAdvancedTaskDefinition(input: AdvancedTaskDefinitionInput!): AdvancedTaskDefinition
     updateAdvancedTaskDefinition(input: UpdateAdvancedTaskDefinitionInput!): AdvancedTaskDefinition

--- a/services/api/src/util/config.ts
+++ b/services/api/src/util/config.ts
@@ -12,9 +12,10 @@ const envVarsConfig = {
   // Maximum number of variables/names accepted by the batch env-var
   // mutations (addOrUpdateEnvVariablesByName / deleteEnvVariablesByName).
   // Override at runtime with the BATCH_ENV_VARS_LIMIT environment variable.
-  batchLimit: process.env.BATCH_ENV_VARS_LIMIT
-    ? parseInt(process.env.BATCH_ENV_VARS_LIMIT, 10)
-    : 20,
+  batchLimit: (() => {
+    const parsed = parseInt(process.env.BATCH_ENV_VARS_LIMIT ?? '', 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 20;
+  })(),
 };
 
 export { envVarsConfig };

--- a/services/api/src/util/config.ts
+++ b/services/api/src/util/config.ts
@@ -8,4 +8,15 @@ const s3Config = {
 
 export { s3Config };
 
+const envVarsConfig = {
+  // Maximum number of variables/names accepted by the batch env-var
+  // mutations (addOrUpdateEnvVariablesByName / deleteEnvVariablesByName).
+  // Override at runtime with the BATCH_ENV_VARS_LIMIT environment variable.
+  batchLimit: process.env.BATCH_ENV_VARS_LIMIT
+    ? parseInt(process.env.BATCH_ENV_VARS_LIMIT, 10)
+    : 20,
+};
+
+export { envVarsConfig };
+
 export { getLagoonRouteFromEnv } from '@lagoon/commons/dist/util/lagoon'

--- a/tests/tasks/api/batch-add-project-variables.gql
+++ b/tests/tasks/api/batch-add-project-variables.gql
@@ -1,0 +1,22 @@
+mutation batchAddEnvVariables {
+  addOrUpdateEnvVariablesByName(
+    input: {
+      project: "{{ project }}"
+      variables: {{ variables | to_json }}
+    }
+  ) {
+    successCount
+    failureCount
+    results {
+      name
+      success
+      error
+      envVariable {
+        id
+        scope
+        name
+        value
+      }
+    }
+  }
+}

--- a/tests/tasks/api/batch-add-project-variables.gql
+++ b/tests/tasks/api/batch-add-project-variables.gql
@@ -2,7 +2,11 @@ mutation batchAddEnvVariables {
   addOrUpdateEnvVariablesByName(
     input: {
       project: "{{ project }}"
-      variables: {{ variables | to_json }}
+      variables: [
+{% for v in variables %}
+        { name: {{ v.name | to_json }}, value: {{ v.value | to_json }}, scope: {{ v.scope }} }{% if not loop.last %},{% endif %}
+{% endfor %}
+      ]
     }
   ) {
     successCount

--- a/tests/tasks/api/batch-add-project-variables.yaml
+++ b/tests/tasks/api/batch-add-project-variables.yaml
@@ -1,0 +1,29 @@
+- name: "{{ testname }} - POST api batch addOrUpdateEnvVariablesByName for project {{ project }} to {{ graphql_url }}"
+  block:
+    - ansible.builtin.include_tasks: admin-token.yaml
+    - name: "{{ testname }} - POST api batch addOrUpdateEnvVariablesByName for project {{ project }} to {{ graphql_url }}"
+      uri:
+        url: "{{ graphql_url }}"
+        method: POST
+        headers:
+          Authorization: "Bearer {{ admin_token }}"
+        body_format: json
+        body:
+          query: '{{ lookup("template", "./batch-add-project-variables.gql") }}'
+      register: apiresponse
+    - name: "{{ testname }} - debug batch addOrUpdateEnvVariablesByName response"
+      debug:
+        msg: "api response: {{ apiresponse.json }}"
+    - fail:
+        msg: "error batch adding environment variables: {{ apiresponse.json }}"
+      when: apiresponse.json.data.addOrUpdateEnvVariablesByName.successCount is not defined
+    - fail:
+        msg: "expected successCount {{ expectedSuccessCount }} but got {{ apiresponse.json.data.addOrUpdateEnvVariablesByName.successCount }}"
+      when:
+        - expectedSuccessCount is defined
+        - apiresponse.json.data.addOrUpdateEnvVariablesByName.successCount != expectedSuccessCount
+    - fail:
+        msg: "expected failureCount {{ expectedFailureCount }} but got {{ apiresponse.json.data.addOrUpdateEnvVariablesByName.failureCount }}"
+      when:
+        - expectedFailureCount is defined
+        - apiresponse.json.data.addOrUpdateEnvVariablesByName.failureCount != expectedFailureCount

--- a/tests/tasks/api/batch-delete-project-variables.gql
+++ b/tests/tasks/api/batch-delete-project-variables.gql
@@ -1,0 +1,16 @@
+mutation batchDeleteEnvVariables {
+  deleteEnvVariablesByName(
+    input: {
+      project: "{{ project }}"
+      names: {{ names | to_json }}
+    }
+  ) {
+    successCount
+    failureCount
+    results {
+      name
+      success
+      error
+    }
+  }
+}

--- a/tests/tasks/api/batch-delete-project-variables.yaml
+++ b/tests/tasks/api/batch-delete-project-variables.yaml
@@ -22,3 +22,8 @@
       when:
         - expectedSuccessCount is defined
         - apiresponse.json.data.deleteEnvVariablesByName.successCount != expectedSuccessCount
+    - fail:
+        msg: "expected failureCount {{ expectedFailureCount }} but got {{ apiresponse.json.data.deleteEnvVariablesByName.failureCount }}"
+      when:
+        - expectedFailureCount is defined
+        - apiresponse.json.data.deleteEnvVariablesByName.failureCount != expectedFailureCount

--- a/tests/tasks/api/batch-delete-project-variables.yaml
+++ b/tests/tasks/api/batch-delete-project-variables.yaml
@@ -1,0 +1,24 @@
+- name: "{{ testname }} - POST api batch deleteEnvVariablesByName for project {{ project }} to {{ graphql_url }}"
+  block:
+    - ansible.builtin.include_tasks: admin-token.yaml
+    - name: "{{ testname }} - POST api batch deleteEnvVariablesByName for project {{ project }} to {{ graphql_url }}"
+      uri:
+        url: "{{ graphql_url }}"
+        method: POST
+        headers:
+          Authorization: "Bearer {{ admin_token }}"
+        body_format: json
+        body:
+          query: '{{ lookup("template", "./batch-delete-project-variables.gql") }}'
+      register: apiresponse
+    - name: "{{ testname }} - debug batch deleteEnvVariablesByName response"
+      debug:
+        msg: "api response: {{ apiresponse.json }}"
+    - fail:
+        msg: "error batch deleting environment variables: {{ apiresponse.json }}"
+      when: apiresponse.json.data.deleteEnvVariablesByName.successCount is not defined
+    - fail:
+        msg: "expected successCount {{ expectedSuccessCount }} but got {{ apiresponse.json.data.deleteEnvVariablesByName.successCount }}"
+      when:
+        - expectedSuccessCount is defined
+        - apiresponse.json.data.deleteEnvVariablesByName.successCount != expectedSuccessCount

--- a/tests/tests/api/batch-project-variables.yaml
+++ b/tests/tests/api/batch-project-variables.yaml
@@ -30,5 +30,5 @@
       - "BATCH_VAR_DOES_NOT_EXIST"
     # Idempotent delete: missing entries still count as success.
     expectedSuccessCount: 4
-  tasks:
+    expectedFailureCount: 0
     - ansible.builtin.include_tasks: ../../tasks/api/batch-delete-project-variables.yaml

--- a/tests/tests/api/batch-project-variables.yaml
+++ b/tests/tests/api/batch-project-variables.yaml
@@ -1,0 +1,34 @@
+- name: "Batch add project variables for {{ project }}"
+  hosts: localhost
+  serial: 1
+  vars:
+    project: "{{ project }}"
+    variables:
+      - name: "BATCH_VAR_ONE"
+        value: "one"
+        scope: BUILD
+      - name: "BATCH_VAR_TWO"
+        value: "two"
+        scope: RUNTIME
+      - name: "BATCH_VAR_THREE"
+        value: "three"
+        scope: GLOBAL
+    expectedSuccessCount: 3
+    expectedFailureCount: 0
+  tasks:
+    - ansible.builtin.include_tasks: ../../tasks/api/batch-add-project-variables.yaml
+
+- name: "Batch delete project variables for {{ project }}"
+  hosts: localhost
+  serial: 1
+  vars:
+    project: "{{ project }}"
+    names:
+      - "BATCH_VAR_ONE"
+      - "BATCH_VAR_TWO"
+      - "BATCH_VAR_THREE"
+      - "BATCH_VAR_DOES_NOT_EXIST"
+    # Idempotent delete: missing entries still count as success.
+    expectedSuccessCount: 4
+  tasks:
+    - ansible.builtin.include_tasks: ../../tasks/api/batch-delete-project-variables.yaml


### PR DESCRIPTION
Closes #4092

## Summary

Adds two new GraphQL mutations on the API service for batch environment variable operations, scoped to a single organization, project, or environment per call:

- `addOrUpdateEnvVariablesByName` — create or update many variables
- `deleteEnvVariablesByName` — delete many variables (idempotent)

Both return a structured `EnvVariableBatchResult` so callers can observe per-entry outcomes when a batch partially fails. See #4092 for the full API rationale, schema, error model, and acceptance criteria.

## API surface

```graphql
input EnvVariableEntryInput {
  name: String!
  value: String!
  scope: EnvVariableScope
}

input EnvVariablesByNameInput {
  organization: String
  project: String
  environment: String
  variables: [EnvVariableEntryInput!]!
}

input DeleteEnvVariablesByNameInput {
  organization: String
  project: String
  environment: String
  names: [String!]!
}

type EnvVariableBatchEntryResult {
  name: String!
  success: Boolean!
  envVariable: EnvKeyValue   # populated on success for upsert; null for delete
  error: String              # populated on per-entry failure
}

type EnvVariableBatchResult {
  successCount: Int!
  failureCount: Int!
  results: [EnvVariableBatchEntryResult!]!
}

addOrUpdateEnvVariablesByName(input: EnvVariablesByNameInput!): EnvVariableBatchResult!
deleteEnvVariablesByName(input: DeleteEnvVariablesByNameInput!): EnvVariableBatchResult!
```

## Behavior

**Targeting** — exactly one of: organization-only, project-only, or project + environment. Any other combination is rejected.

**Two-tier error model**

- Whole-batch errors (throw, no rows written): empty list, oversize batch, invalid target combo, target not found, permission denied, project restriction violated.
- Per-entry errors (caught and reported in `results`, sibling entries continue): empty/blank `name`, deprecated `internal_container_registry` scope, DB constraint errors.

**Delete is idempotent** — a name that does not exist for the target reports `success: true`. This lets sync workflows declare "these N should not exist" without first querying.

**Permission and project-restriction checks run once per call** for the shared target, reusing the existing Keycloak scopes (`env_var:project:add`, `env_var:environment:add:{type}`, `organization:addEnvVar`, and the corresponding `:delete` scopes) — no new scopes were added.

**Atomicity** — per-entry try/catch in a loop, no DB transaction. Pre-flight validation makes mid-batch failures unlikely; when they happen, the result tells the caller exactly which entries persisted. Modeled on the existing `processAddFacts` pattern.

**Audit log** — one `userActivityLogger` entry per call summarizing the batch (envVarType, target name, count, successCount, failureCount, names list), not one per entry.

**Batch size limit** — default 20 entries, overridable via the `BATCH_ENV_VARS_LIMIT` env var on the API service (consistent with other env-driven config in `services/api/src/util/config.ts`). Oversize batches are rejected as a whole-batch error so the client knows to chunk. A TODO is left in the resolver noting that automatic server-side chunking could be added if usage warrants it.

## Files changed

| File | Change |
|---|---|
| `services/api/src/typeDefs.js` | Added 2 types, 3 inputs, 2 mutations |
| `services/api/src/util/config.ts` | Added `envVarsConfig.batchLimit` |
| `services/api/src/resources/env-variables/resolvers.ts` | Added `resolveEnvVarBatchTarget`, `upsertEnvVarRowForTarget`, `deleteEnvVarRowByNameForTarget`, `enforceBatchSize` helpers and the two new resolvers |
| `services/api/src/resolvers.js` | Wired the two new resolvers into the Mutation map |
| `tests/tasks/api/batch-add-project-variables.{gql,yaml}` | New Ansible task templates |
| `tests/tasks/api/batch-delete-project-variables.{gql,yaml}` | New Ansible task templates |
| `tests/tests/api/batch-project-variables.yaml` | Wrapper playbook (batch add 3 vars, batch delete 4 names including a non-existent one to verify idempotency) |

The existing singular `addOrUpdateEnvVariableByName` / `deleteEnvVariableByName` resolvers are **untouched** — this change is purely additive. No DB migration. No new Keycloak scopes.

## Example

```graphql
mutation BatchAdd($input: EnvVariablesByNameInput!) {
  addOrUpdateEnvVariablesByName(input: $input) {
    successCount
    failureCount
    results {
      name
      success
      error
      envVariable { id scope name value }
    }
  }
}
```

```json
{
  "input": {
    "project": "my-project",
    "environment": "main",
    "variables": [
      { "name": "API_TOKEN",  "value": "...", "scope": "RUNTIME" },
      { "name": "BUILD_FLAG", "value": "1",    "scope": "BUILD"   },
      { "name": "FEATURE_X",  "value": "on",   "scope": "GLOBAL"  }
    ]
  }
}
```

## Verification

- `yarn workspace api run build` — passes (TypeScript clean).
- `yarn workspace api run test` — same 4 pre-existing snapshot/redis failures as `main` (notification, environment, advancedtasktoolbox, sshKey); no new failures introduced.
- Local API loop available via `make api-development` for iterating on GraphQL changes without spinning up the full stack — used to verify mutations against the API.

## Acceptance criteria (from #4092)

- [x] `addOrUpdateEnvVariablesByName` accepts org / project / environment-scoped batches and returns an `EnvVariableBatchResult`.
- [x] `deleteEnvVariablesByName` accepts the same scoping and returns an `EnvVariableBatchResult`; deleting a non-existent name reports `success: true`.
- [x] Whole-batch errors (target / permission / restriction / size / empty) throw and do not write any rows.
- [x] Per-entry errors (validation, DB constraint) are reported in `results` and do not abort sibling entries.
- [x] Permission and project-restriction checks run once per call for the shared target.
- [x] Existing singular mutations are unchanged.
- [x] Batch size limit defaults to 20, overridable via `BATCH_ENV_VARS_LIMIT`.
- [x] One audit log entry per call summarizing the batch.
- [x] Integration tests cover: project-scoped batch add, partial-failure reporting, delete with a missing name (idempotency).
