### PR TITLE
Update Keycloak to version 26.5.7 and dependencies

### DIFF
--- a/services/keycloak/Dockerfile
+++ b/services/keycloak/Dockerfile
@@ -1,5 +1,5 @@
 # Stage: Build the custom token mapper
-FROM maven:3.9.14-eclipse-temurin-21-alpine as builder
+FROM maven:3.9.16-eclipse-temurin-21-alpine as builder
 COPY custom-mapper/. .
 RUN mvn clean compile package
 
@@ -20,7 +20,7 @@ COPY javascript /tmp/lagoon-scripts
 RUN cd /tmp/lagoon-scripts && zip -r ../lagoon-scripts.jar *
 
 # Stage: Build the keycloak image
-FROM quay.io/keycloak/keycloak:26.4.7
+FROM quay.io/keycloak/keycloak:26.5.7
 COPY --from=ubi-micro-build /mnt/rootfs /
 
 ARG LAGOON_VERSION
@@ -87,7 +87,7 @@ ENV TMPDIR=/tmp \
 
 VOLUME /opt/keycloak/data
 
-RUN curl -sSLo /opt/keycloak/providers/keycloak-home-idp-discovery.jar https://github.com/sventorben/keycloak-home-idp-discovery/releases/download/v26.1.1/keycloak-home-idp-discovery.jar
+RUN curl -sSLo /opt/keycloak/providers/keycloak-home-idp-discovery.jar https://github.com/sventorben/keycloak-home-idp-discovery/releases/download/v26.2.0/keycloak-home-idp-discovery.jar
 
 COPY entrypoints/kc-startup.sh /lagoon/kc-startup.sh
 COPY entrypoints/wait-for-mariadb.sh /lagoon/entrypoints/98-wait-for-mariadb.sh
@@ -97,7 +97,7 @@ COPY startup-scripts /opt/keycloak/startup-scripts
 COPY themes/lagoon /opt/keycloak/themes/lagoon
 COPY themes/lagoon-v2 /opt/keycloak/themes/lagoon-v2
 COPY --from=commons /tmp/lagoon-scripts.jar /opt/keycloak/providers/lagoon-scripts.jar
-COPY --from=builder /target/custom-protocol-mapper-1.1.1.jar /opt/keycloak/providers/custom-protocol-mapper-1.1.1.jar
+COPY --from=builder /target/custom-protocol-mapper-1.1.2.jar /opt/keycloak/providers/custom-protocol-mapper-1.1.2.jar
 
 COPY lagoon-realm-base-import.json /lagoon/seed/lagoon-realm-base-import.json
 

--- a/services/keycloak/custom-mapper/pom.xml
+++ b/services/keycloak/custom-mapper/pom.xml
@@ -6,11 +6,11 @@
 
     <groupId>net.cake.keycloak.custom</groupId>
     <artifactId>custom-protocol-mapper</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
     <packaging>jar</packaging>
 
     <properties>
-        <keycloak.version>26.4.7</keycloak.version>
+        <keycloak.version>26.5.7</keycloak.version>
     </properties>
 
     <dependencies>
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
-            <version>3.4.0</version>
+            <version>3.5.8</version>
         </dependency>
 
     </dependencies>
@@ -52,7 +52,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
+                <version>3.14.1</version>
                 <configuration>
                     <forceJavacCompilerUse>true</forceJavacCompilerUse>
                     <source>1.8</source>
@@ -62,7 +62,7 @@
             <plugin>
                 <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>3.2.2</version>
+                <version>3.5.3</version>
                 <executions>
                     <execution>
                         <id>make-index</id>
@@ -75,7 +75,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>3.6.2</version>
                 <executions>
                     <!-- Run shade goal on package phase -->
                     <execution>


### PR DESCRIPTION
This pull request updates the Keycloak service and its custom protocol mapper to use newer versions of Keycloak, dependencies, and build tools. The changes improve compatibility, security, and maintainability by keeping the stack up to date.

**Keycloak and Custom Mapper Version Upgrades:**

* Upgraded the Keycloak base image in `services/keycloak/Dockerfile` from `26.4.7` to `26.5.7`, and updated the `keycloak.version` property in `custom-mapper/pom.xml` accordingly. [[1]](diffhunk://#diff-a73572d2bf8ca702584a1173ce50d2ddce884c4ade3736de21549c437b02f836L23-R23) [[2]](diffhunk://#diff-baffeabe06e1f61d41c64815ab31aad7e9b66337c6dc2815a6839bdf3e4b433eL9-R13)
* Updated the custom protocol mapper version from `1.1.1` to `1.1.2` in both the `Dockerfile` and `pom.xml`. [[1]](diffhunk://#diff-a73572d2bf8ca702584a1173ce50d2ddce884c4ade3736de21549c437b02f836L100-R100) [[2]](diffhunk://#diff-baffeabe06e1f61d41c64815ab31aad7e9b66337c6dc2815a6839bdf3e4b433eL9-R13)

**Dependency and Plugin Updates:**

* Upgraded the `mariadb-java-client` dependency from `3.4.0` to `3.5.8` in `custom-mapper/pom.xml`.
* Updated Maven plugin versions in `custom-mapper/pom.xml`:
  - `maven-compiler-plugin` from `3.13.0` to `3.14.1`
  - `jandex-maven-plugin` from `3.2.2` to `3.5.3`
  - `maven-shade-plugin` from `3.6.0` to `3.6.2`
* Updated Maven build image in `Dockerfile` from `3.9.14-eclipse-temurin-21-alpine` to `3.9.16-eclipse-temurin-21-alpine`.

**Provider and Extension Updates:**

* Updated the `keycloak-home-idp-discovery` provider JAR from version `v26.1.1` to `v26.2.0` in the Keycloak Dockerfile.