### PR TITLE
WIP - Testing gha/build images

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,127 @@
+name: Build and Publish Images
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - 'testing-gha/**'
+    tags:
+      - 'v*'
+
+# Targets per trigger:
+#   PRs & testing/* branches → docker.io/testlagoon:<branch-tag>  (multi-arch)
+#   main branch              → docker.io/testlagoon:main + :latest (multi-arch)
+#   tags (v*)               → docker.io/uselagoon:<tag> + :latest  (multi-arch)
+#                             ghcr.io/uselagoon:<tag> + :latest     (multi-arch)
+
+permissions:
+  contents: read
+  packages: write  # required for GHCR pushes on tags
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0  # needed for git describe to find tags
+
+      - name: Compute image tag and version
+        id: meta
+        run: |
+          LAGOON_VERSION=$(git describe --tags --exact-match 2>/dev/null || echo development)
+          LAGOON_SYNC_GIT_BRANCH=$(grep '^LAGOON_SYNC_GIT_BRANCH ' Makefile | awk '{print $NF}')
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            RAW="${{ github.head_ref }}"
+          else
+            RAW="${{ github.ref_name }}"
+          fi
+          # Sanitise: lowercase, replace non-alphanumeric (except . _ -) with -, truncate to 128
+          BRANCH_TAG=$(echo "$RAW" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9._-]/-/g' | cut -c1-128)
+
+          echo "lagoon_version=$LAGOON_VERSION" >> "$GITHUB_OUTPUT"
+          echo "lagoon_sync_git_branch=$LAGOON_SYNC_GIT_BRANCH" >> "$GITHUB_OUTPUT"
+          echo "branch_tag=$BRANCH_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3  # pin to SHA for production use
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GHCR
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # ── PRs and testing/* branches ──────────────────────────────────────────
+      # Cache is keyed per-branch; also falls back to main's cache so PRs get a
+      # warm start even on first run. Cache is written back after each build.
+      - name: Push to testlagoon (PR / testing branch)
+        if: github.event_name == 'pull_request' || startsWith(github.ref, 'refs/heads/testing-gha/')
+        env:
+          PLATFORMS: linux/amd64,linux/arm64
+          IMAGE_REPO: docker.io/testlagoon
+          TAG: ${{ steps.meta.outputs.branch_tag }}
+          LAGOON_VERSION: ${{ steps.meta.outputs.lagoon_version }}
+          LAGOON_SYNC_GIT_BRANCH: ${{ steps.meta.outputs.lagoon_sync_git_branch }}
+        run: |
+          docker buildx bake -f docker-bake.hcl \
+            --set "*.cache-from=type=gha,scope=lagoon-${{ steps.meta.outputs.branch_tag }}" \
+            --set "*.cache-from=type=gha,scope=lagoon-main" \
+            --set "*.cache-to=type=gha,scope=lagoon-${{ steps.meta.outputs.branch_tag }},mode=max" \
+            --push
+
+      # ── main branch — always builds fresh, no cache ─────────────────────────
+      - name: Push to testlagoon (main branch)
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        env:
+          PLATFORMS: linux/amd64,linux/arm64
+          IMAGE_REPO: docker.io/testlagoon
+          LAGOON_VERSION: ${{ steps.meta.outputs.lagoon_version }}
+          LAGOON_SYNC_GIT_BRANCH: ${{ steps.meta.outputs.lagoon_sync_git_branch }}
+        run: |
+          for TAG in main latest; do
+            TAG="$TAG" docker buildx bake -f docker-bake.hcl --push
+          done
+
+      # ── Tags — always build fresh, no cache ──────────────────────────────────
+      # Build once and push to docker.io/uselagoon. Then use imagetools create to
+      # copy the already-built multi-arch manifests to ghcr.io/uselagoon —
+      # no second build, guaranteed identical digests across both registries.
+      - name: Push to uselagoon DockerHub and GHCR (tag)
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          PLATFORMS: linux/amd64,linux/arm64
+          IMAGE_REPO: docker.io/uselagoon
+          LAGOON_VERSION: ${{ steps.meta.outputs.lagoon_version }}
+          LAGOON_SYNC_GIT_BRANCH: ${{ steps.meta.outputs.lagoon_sync_git_branch }}
+        run: |
+          for TAG in "${{ github.ref_name }}" latest; do
+            IMAGE_REPO=docker.io/uselagoon TAG="$TAG" \
+              docker buildx bake -f docker-bake.hcl --push
+
+            # Mirror every pushed manifest to GHCR — imagetools create copies the
+            # manifest list directly, so digests are identical to DockerHub.
+            IMAGE_REPO=docker.io/uselagoon TAG="$TAG" \
+              docker buildx bake -f docker-bake.hcl --print 2>/dev/null \
+              | jq -r '.target[].tags[]' \
+              | while IFS= read -r src; do
+                  dest="${src/docker.io\/uselagoon/ghcr.io\/uselagoon}"
+                  docker buildx imagetools create --tag "$dest" "$src"
+                done
+          done

--- a/services/actions-handler/Dockerfile
+++ b/services/actions-handler/Dockerfile
@@ -1,13 +1,14 @@
 # build the binary
 ARG UPSTREAM_REPO
 ARG UPSTREAM_TAG
-FROM golang:1.25-alpine3.22 AS builder
+FROM --platform=linux/amd64 golang:1.25-alpine3.22 AS builder
+ARG TARGETARCH
 # bring in all the packages
 COPY . /go/src/github.com/uselagoon/lagoon/services/actions-handler/
 WORKDIR /go/src/github.com/uselagoon/lagoon/services/actions-handler/
 
 # compile
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -o actions-handler .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -a -o actions-handler .
 
 # put the binary into container
 # use the commons image to get entrypoints

--- a/services/api-sidecar-handler/Dockerfile
+++ b/services/api-sidecar-handler/Dockerfile
@@ -1,13 +1,14 @@
 # build the binary
 ARG UPSTREAM_REPO
 ARG UPSTREAM_TAG
-FROM golang:1.25-alpine3.22 AS builder
+FROM --platform=linux/amd64 golang:1.25-alpine3.22 AS builder
+ARG TARGETARCH
 # bring in all the packages
 COPY . /go/src/github.com/uselagoon/lagoon/services/api-sidecar-handler/
 WORKDIR /go/src/github.com/uselagoon/lagoon/services/api-sidecar-handler/
 
 # compile
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -o api-sidecar-handler .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -a -o api-sidecar-handler .
 
 # put the binary into container
 # use the commons image to get entrypoints

--- a/services/backup-handler/Dockerfile
+++ b/services/backup-handler/Dockerfile
@@ -1,14 +1,15 @@
 # build the binary
 ARG UPSTREAM_REPO
 ARG UPSTREAM_TAG
-FROM golang:1.25-alpine3.22 AS builder
+FROM --platform=linux/amd64 golang:1.25-alpine3.22 AS builder
+ARG TARGETARCH
 
 # bring in all the packages
 COPY . /go/src/github.com/uselagoon/lagoon/services/backup-handler/
 WORKDIR /go/src/github.com/uselagoon/lagoon/services/backup-handler/
 
 # compile
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -o backup-handler .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -a -o backup-handler .
 
 # put the binary into container
 # use the commons image to get entrypoints

--- a/services/keycloak/Dockerfile
+++ b/services/keycloak/Dockerfile
@@ -1,9 +1,11 @@
 # Stage: Build the custom token mapper
-FROM maven:3.9.9-eclipse-temurin-21-alpine as builder
+# Force amd64 so Maven always runs natively - the output is JVM bytecode and is
+# architecture-neutral, so the resulting JAR works in both amd64 and arm64 images.
+# Running under QEMU arm64 emulation causes TLS handshake failures when Maven
+# tries to connect to Maven Central, which this avoids entirely.
+FROM --platform=linux/amd64 maven:3.9.9-eclipse-temurin-21-alpine as builder
 COPY custom-mapper/. .
-# Use /dev/urandom as entropy source to prevent TLS handshake failures under
-# QEMU arm64 emulation, where /dev/random can block or produce spurious errors.
-RUN MAVEN_OPTS="-Djava.security.egd=file:/dev/./urandom" mvn clean compile package
+RUN mvn clean compile package
 
 # Stage: Install package dependencies
 FROM registry.access.redhat.com/ubi9 AS ubi-micro-build

--- a/services/keycloak/Dockerfile
+++ b/services/keycloak/Dockerfile
@@ -1,7 +1,9 @@
 # Stage: Build the custom token mapper
 FROM maven:3.9.9-eclipse-temurin-21-alpine as builder
 COPY custom-mapper/. .
-RUN mvn clean compile package
+# Use /dev/urandom as entropy source to prevent TLS handshake failures under
+# QEMU arm64 emulation, where /dev/random can block or produce spurious errors.
+RUN MAVEN_OPTS="-Djava.security.egd=file:/dev/./urandom" mvn clean compile package
 
 # Stage: Install package dependencies
 FROM registry.access.redhat.com/ubi9 AS ubi-micro-build

--- a/services/logs2notifications/Dockerfile
+++ b/services/logs2notifications/Dockerfile
@@ -1,13 +1,14 @@
 # build the binary
 ARG UPSTREAM_REPO
 ARG UPSTREAM_TAG
-FROM golang:1.25-alpine3.22 AS builder
+FROM --platform=linux/amd64 golang:1.25-alpine3.22 AS builder
+ARG TARGETARCH
 # bring in all the packages
 COPY . /go/src/github.com/uselagoon/lagoon/services/logs2notifications/
 WORKDIR /go/src/github.com/uselagoon/lagoon/services/logs2notifications/
 
 # compile
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -o logs2notifications .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -a -o logs2notifications .
 
 # put the binary into container
 # use the commons image to get entrypoints

--- a/taskimages/activestandby/Dockerfile
+++ b/taskimages/activestandby/Dockerfile
@@ -1,11 +1,12 @@
 # Build the binary
-FROM golang:1.25-alpine3.22 AS builder
+FROM --platform=linux/amd64 golang:1.25-alpine3.22 AS builder
+ARG TARGETARCH
 
 COPY . /go/src/github.com/uselagoon/lagoon/taskimages/activestandby/
 WORKDIR /go/src/github.com/uselagoon/lagoon/taskimages/activestandby/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -o taskrunner .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -a -o taskrunner .
 
 # Use distroless as minimal base image to package the binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/taskimages/projectclone/Dockerfile
+++ b/taskimages/projectclone/Dockerfile
@@ -1,20 +1,22 @@
 # Build the binary
-FROM golang:1.25-alpine3.22 AS builder
+FROM --platform=linux/amd64 golang:1.25-alpine3.22 AS builder
+ARG TARGETARCH
 
 COPY . /go/src/github.com/uselagoon/lagoon/taskimages/projectclone/
 WORKDIR /go/src/github.com/uselagoon/lagoon/taskimages/projectclone/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -o taskrunner .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -a -o taskrunner .
 
 # Add lagoon-sync - need to test this will work
-FROM golang:1.25-alpine3.22 AS syncer
+FROM --platform=linux/amd64 golang:1.25-alpine3.22 AS syncer
+ARG TARGETARCH
 ARG LAGOON_SYNC_GIT_BRANCH
 RUN apk add --no-cache git
 WORKDIR /go/src/github.com/uselagoon/lagoon-sync
 RUN git clone https://github.com/uselagoon/lagoon-sync.git . && \
     git checkout ${LAGOON_SYNC_GIT_BRANCH} && \
-    CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -o /lagoon-sync
+    CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -o /lagoon-sync
 
 # Switching to commons image
 FROM ${UPSTREAM_REPO:-uselagoon}/commons:${UPSTREAM_TAG:-latest}

--- a/yarn-workspace-builder/Dockerfile
+++ b/yarn-workspace-builder/Dockerfile
@@ -13,6 +13,6 @@ COPY services/auth-server/package.json /app/services/auth-server/
 COPY services/webhook-handler/package.json /app/services/webhook-handler/
 COPY services/webhooks2tasks/package.json /app/services/webhooks2tasks/
 
-RUN yarn install --frozen-lockfile
+RUN yarn install --frozen-lockfile --network-timeout 600000
 
 RUN cd /app/node-packages/commons && yarn build


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for building and publishing multi-architecture Docker images, and updates several Dockerfiles to improve multi-arch build support and reliability. The changes focus on standardizing build environments, ensuring consistent architecture targeting, and improving build robustness.

**CI/CD and Build Improvements:**

* Added a new workflow `.github/workflows/build-images.yml` to automate building and publishing Docker images for different branches and tags, supporting multi-architecture builds and mirroring images to DockerHub and GHCR.
* Updated Node.js workspace Dockerfile to increase the `yarn` network timeout, improving reliability in environments with slow network connections.

**Dockerfile Multi-Architecture and Build Consistency:**

* Updated all Go-based service and task image Dockerfiles (`services/actions-handler`, `services/api-sidecar-handler`, `services/backup-handler`, `services/logs2notifications`, `taskimages/activestandby`, `taskimages/projectclone`) to:
  * Explicitly specify `--platform=linux/amd64` for the builder stage to ensure native builds and avoid QEMU-related issues.
  * Use the `TARGETARCH` build argument for the Go `GOARCH` environment variable, enabling correct cross-compilation for multi-arch images. [[1]](diffhunk://#diff-7ffdcf118910734f1aa1640043259bc9b9ca2064a278ac407f2804f484e49b43L4-R11) [[2]](diffhunk://#diff-b8f395ae92ef7d5b300f29d9846d7235dcbc608f93f62641694ee836dd0b146cL4-R11) [[3]](diffhunk://#diff-852ca9b8e599e14188044fa60dac5eeda09ce55a5176d66c0a03f1ef4f7387b1L4-R12) [[4]](diffhunk://#diff-002978cf19451fe1c13966444746f716e6fa0827646f986e5a7127679d36ed7eL4-R11) [[5]](diffhunk://#diff-2ae7280a9c6f4d90459c8a9d688790bfc42e603a5402e8c3f622e14db7a23601L2-R9) [[6]](diffhunk://#diff-734db615bbbc450b5b92bc940e67027a84bbc79e4e3a4339a4cd9a356ce1bfdcL2-R19)

* Updated the `taskimages/projectclone` Dockerfile to also apply these changes to the `lagoon-sync` build stage.

* Updated the `services/keycloak` Dockerfile to force the Maven build stage to use `linux/amd64`, avoiding TLS handshake failures under QEMU emulation and ensuring the resulting JAR is architecture-neutral.