### PR TITLE
fix: race condition when making multiple keycloak API calls

### DIFF
--- a/services/api/src/clients/keycloak-admin.ts
+++ b/services/api/src/clients/keycloak-admin.ts
@@ -29,6 +29,11 @@ export const getKeycloakAdminClient = async (): Promise<KeycloakAdminClient> => 
     realmName: config.realm,
   });
 
+  const tokenProviderClient = new KeycloakAdminClient({
+    baseUrl: `${config.origin}/auth`,
+    realmName: 'master', // auth against the `master` realm
+  });
+
   /**
    * Use a custom token provider that can automatically refresh expired tokens.
    */
@@ -46,13 +51,7 @@ export const getKeycloakAdminClient = async (): Promise<KeycloakAdminClient> => 
         logger.debug('keycloakAdminClient: refreshing expired token');
       }
 
-      // Always auth against master realm.
-      const curRealm = keycloakAdminClient.realmName;
-      keycloakAdminClient.setConfig({
-        realmName: 'master',
-      });
-
-      await keycloakAdminClient.auth({
+      await tokenProviderClient.auth({
         grantType: 'client_credentials',
         clientId: 'admin-api',
         clientSecret: getConfigFromEnv(
@@ -61,10 +60,7 @@ export const getKeycloakAdminClient = async (): Promise<KeycloakAdminClient> => 
         ),
       });
 
-      keycloakAdminClient.setConfig({
-        realmName: curRealm,
-      });
-
+      keycloakAdminClient.accessToken = tokenProviderClient.accessToken;
       return keycloakAdminClient.accessToken;
     },
   });

--- a/services/api/src/models/group.ts
+++ b/services/api/src/models/group.ts
@@ -161,7 +161,7 @@ export interface GroupModel {
   removeProjectFromGroup: (projectId: number, group: Group) => Promise<void>
   removeProjectFromGroups: (projectId: number, groups: Group[]) => Promise<void>
   transformKeycloakGroups: (keycloakGroups: GroupRepresentation[]) => Promise<Group[]>
-  getGroupMembership: (group: Group) => Promise<GroupMembership[]>
+  getGroupMembership: (group: Group, useCache?: boolean) => Promise<GroupMembership[]>
   getGroupMemberCount: (group: Group) => Promise<number>
   removeNonProjectDefaultUsersFromGroup: (group: Group, project: String) => Promise<Group>
   purgeGroupCache: (group: Pick<Group, 'name' | 'id'>, membersOnly: Boolean) => Promise<void>


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Database Migrations

n/a

# Description

A shared keycloak client is used in the Lagoon API. A race condition exists where an API request can fail or return unexpected data if it is done in the middle of another API request getting an access token.

The fix is to use a new/separate keycloak client for access tokens.

The easiest way to reproduce is to run the query described in #3907, but [disable the group member cache](https://github.com/uselagoon/lagoon/blob/main/services/api/src/resources/group/resolvers.ts#L153) so it is 100% reproducible:

```suggestion
const members = await models.GroupModel.getGroupMembership(group, false);
```

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

closes #3907 
