### PR TITLE
fix: multiple issues with local-api-data-watcher-pusher

### DIFF
--- a/docker-compose.local-dev.yaml
+++ b/docker-compose.local-dev.yaml
@@ -45,4 +45,4 @@ services:
       - "./local-dev/keycloak:/lagoon/keycloak"
   local-api-data-watcher-pusher:
     volumes:
-      - ./local-dev/api-data-watcher-pusher:/home
+      - ./local-dev/api-data-watcher-pusher:/app

--- a/local-dev/api-data-watcher-pusher/Dockerfile
+++ b/local-dev/api-data-watcher-pusher/Dockerfile
@@ -1,5 +1,8 @@
 FROM ${UPSTREAM_REPO:-uselagoon}/commons:${UPSTREAM_TAG:-latest}
 
+RUN mkdir -p /app \
+    && fix-permissions /app
+
 RUN apk add --no-cache \
       bash \
       curl \
@@ -17,8 +20,9 @@ ENV JWTSECRET=super-secret-string \
     INGRESS_IP="172.17.0.1" \
     TOKEN="eyJhbGciOiJSUzI1NiIsImtpZCI6IjZWamZLTzEzZ2lPSGFtc0d6QXVkWXpDYi1fcmlfLWVBd3JtbEEydGItTHcifQ.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJsYWdvb24iLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlY3JldC5uYW1lIjoia3ViZXJuZXRlc2J1aWxkZGVwbG95LXRva2VuLXJxNDg1Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZXJ2aWNlLWFjY291bnQubmFtZSI6Imt1YmVybmV0ZXNidWlsZGRlcGxveSIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50LnVpZCI6IjA3YzViODAxLTI5ZDgtNDU5Ni1hODBlLTZlMmU3MmY3YmMwMCIsInN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDpsYWdvb246a3ViZXJuZXRlc2J1aWxkZGVwbG95In0.srj-zZguNXCQbeTIS5GtJw7Jl61k_miC8hXED70NQULm6OAMkImHrURRCfD4kjKPy-jbwEI88m5TNLFP8_0sMfdwj2vr2Gv8fTC55qoAJ589ff_dwv8THSKdKNj6VaHynzEzQ4IfZscd3ogP4HYF9alt-X4mMcJ2BApBt4F13Hg-bE2-4uzO0b_u13pJhzn0XrH8JGXWP0_oMPtE7M0zJL9BfOrBph_MgSb2djSbVBNbhPJ0fs9-eIB5aAu0NmqPhpxj6WL4UOAKX178IsDAq4vtRZrScZwvZxRcaDUxZ-MgwewWI8Ll0yg7UCxtZTdkLglkCgpjTK33Ei0PXWdE4A"
 
-COPY api-data /home/api-data
-COPY minio-data /home/minio-data
-COPY data-init-push.sh create_jwt.py /home/
+WORKDIR /app
 
-CMD ["/sbin/tini", "--", "/home/data-init-push.sh"]
+COPY . .
+
+ENTRYPOINT ["/sbin/tini", "--", "/lagoon/entrypoints.sh"]
+CMD ["/app/data-init-push.sh"]

--- a/local-dev/api-data-watcher-pusher/data-init-push.sh
+++ b/local-dev/api-data-watcher-pusher/data-init-push.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 # inject variables from environment into the GQL template
-envsubst '$GIT_HOST $GIT_PORT $INGRESS_IP $CONSOLE_URL $TOKEN' < /home/api-data/03-populate-api-data-ci-local-control-k8s.gql | sponge /home/api-data/03-populate-api-data-ci-local-control-k8s.gql
+envsubst '$GIT_HOST $GIT_PORT $INGRESS_IP $CONSOLE_URL $TOKEN' < /app/api-data/03-populate-api-data-ci-local-control-k8s.gql | sponge /app/api-data/03-populate-api-data-ci-local-control-k8s.gql
 
-populate_demo_lagoon_gql_file_path="/home/api-data/01-populate-api-data-lagoon-demo.gql"
-populate_demo_lagoon_org_gql_file_path="/home/api-data/02-populate-api-data-lagoon-demo-org.gql"
-populate_ci_local_control_k8s_gql_file_path="/home/api-data/03-populate-api-data-ci-local-control-k8s.gql"
-sample_task_file_path="/home/minio-data/task-files/sample-task-file.txt"
+populate_demo_lagoon_gql_file_path="/app/api-data/01-populate-api-data-lagoon-demo.gql"
+populate_demo_lagoon_org_gql_file_path="/app/api-data/02-populate-api-data-lagoon-demo-org.gql"
+populate_ci_local_control_k8s_gql_file_path="/app/api-data/03-populate-api-data-ci-local-control-k8s.gql"
+sample_task_file_path="/app/minio-data/task-files/sample-task-file.txt"
 
 wait_for_services() {
     echo "waiting for ${API_HOST:-api}:${API_PORT:-3000}"
@@ -17,7 +17,7 @@ wait_for_services() {
 send_graphql_query() {
     local file_path=${1}
 
-    API_ADMIN_JWT_TOKEN=$(/home/create_jwt.py)
+    API_ADMIN_JWT_TOKEN=$(/app/create_jwt.py)
 
     bearer="Authorization: bearer $API_ADMIN_JWT_TOKEN"
 
@@ -31,16 +31,16 @@ send_graphql_query() {
 }
 
 update_minio_files() {
-	mcli config host add local-minio ${MINIO_SERVER_URL-http://local-minio:9000} ${MINIO_ROOT_USER:-minio} ${MINIO_ROOT_PASSWORD:-minio123}
-	mcli cp --recursive /home/minio-data/lagoon-files/ local-minio/lagoon-files
-	mcli cp --recursive /home/minio-data/restores/ local-minio/restores
+	mcli alias set local-minio ${MINIO_SERVER_URL-http://local-minio:9000} ${MINIO_ROOT_USER:-minio} ${MINIO_ROOT_PASSWORD:-minio123}
+	mcli cp --recursive /app/minio-data/lagoon-files/ local-minio/lagoon-files
+	mcli cp --recursive /app/minio-data/restores/ local-minio/restores
 }
 
 send_task_data() {
     local task_id=${1}
     local file_path=${2}
 
-    API_ADMIN_JWT_TOKEN=$(/home/create_jwt.py)
+    API_ADMIN_JWT_TOKEN=$(/app/create_jwt.py)
 
     bearer="Authorization: bearer $API_ADMIN_JWT_TOKEN"
 


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Database Migrations

n/a

# Description

Fixes a number of issues discovered in `local-api-data-watcher-pusher`:


> mcli: <ERROR> `config` is not a recognized command. Get help using `--help` flag.

There is no `config` command for `mcli`. Maybe it was removed in some version, but all the `mcli cp` calls have been failing silently for awhile. The files were being written to a folder called `local-minio` instead of the minio service. Fixed by using correct `alias` command.

> $ git worktree remove test-mcli-error
> warning: could not open directory 'local-dev/api-data-watcher-pusher/.mcli/': Permission denied
> error: failed to delete 'test-mcli-error': Directory not empty

This is an annoyance for local development. Running `mcli alias set` creates a `/home/.mcli` folder with root permisisons. Since docker-compose mounts `/home` to the host it requires `sudo` to clean up the folder on the host. Fix is to run and mount scripts out of `/app` instead of `/home`.

> [WARN  tini (7)] Tini is not running as PID 1 and isn't registered as a child subreaper.
> Zombie processes will not be re-parented to Tini, so zombie reaping won't work.
> To fix the problem, use the -s option or set the environment variable TINI_SUBREAPER to register Tini as a child subreaper, or run Tini as PID 1.

Just a warning, but easy to fix by running `tini` as the entrypoint only, not in the command.

> "errors":[{"message":"Error: Provided harbor configuration is not valid: Error: all branches, excluding pullrequests: latestPushed must be a number"

There is still one error left, will address in #4108.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

n/a
