### PR TITLE
fix: harbor retention rule `latestPushed` is optional

### DIFF
--- a/services/api/src/resources/retentionpolicy/types.ts
+++ b/services/api/src/resources/retentionpolicy/types.ts
@@ -73,7 +73,7 @@ export const RetentionPolicy = () => {
             if (typeof rule.latestPulled != "number") {
                 throw new Error(`${rule.name}: latestPulled must be a number`);
             }
-            if (typeof rule.latestPushed != "number") {
+            if (rule.latestPushed && typeof rule.latestPushed != "number") {
                 throw new Error(`${rule.name}: latestPushed must be a number`);
             }
         }


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Database Migrations

n/a

# Description

Follow up to #4074. `latestPushed` is supposed to be optional, but leaving it off throws an error:

```graphql
createHarborRetentionPolicy(input:{
    name: "harbor-policy"
    enabled: true
    rules: [
      {
        name: "all branches, excluding pullrequests"
        pattern: "[^pr-]*/*"
        latestPulled: 3
      },
      {
        name: "pullrequests"
        pattern: "pr-*"
        latestPulled: 1
      }
    ]
    schedule: "3 * * * *"
  }) {
    id
    name
    configuration {
      enabled
      rules {
        name
        pattern
        latestPulled
      }
      schedule
    }
    created
    updated
  }
```
```
Error: Provided harbor configuration is not valid: Error: all branches, excluding pullrequests: latestPushed must be a number
```

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

n/a
