### PR TITLE
chore: ARM image builds are not completing in time, disable temporarily

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -181,27 +181,6 @@ pipeline {
         }
       }
     }
-    stage ('build arm images and push all images to testlagoon/*') {
-      when {
-        expression {
-            !skipRemainingStages
-        }
-      }
-      environment {
-        PASSWORD = credentials('amazeeiojenkins-dockerhub-password')
-      }
-      steps {
-        retry(3) {
-          timeout(time: 30, unit: 'MINUTES') {
-            sh script: "make -j$NPROC -O build PLATFORM_ARCH=linux/arm64", label: "Building arm images"
-          }
-        }
-        retry(3) {
-          sh script: 'docker login -u amazeeiojenkins -p $PASSWORD', label: "Docker login"
-          sh script: "timeout 12m make -O publish-testlagoon-images PUBLISH_PLATFORM_ARCH=linux/arm64,linux/amd64 BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Publishing built images"
-        }
-      }
-    }
     stage ('push images to testlagoon/* with :latest tag') {
        when {
         branch 'main'
@@ -217,7 +196,7 @@ pipeline {
       }
       steps {
         sh script: 'docker login -u amazeeiojenkins -p $PASSWORD', label: "Docker login"
-        sh script: "make -O publish-testlagoon-images BRANCH_NAME=latest", label: "Publishing built images with :latest tag"
+        sh script: "make -O publish-testlagoon-images PUBLISH_PLATFORM_ARCH=linux/amd64 BRANCH_NAME=latest", label: "Publishing built amd64 images with :latest tag"
       }
     }
     stage ('deploy to test environment') {
@@ -239,6 +218,28 @@ pipeline {
         }
       }
     }
+    // stage ('build arm images and push to testlagoon/*') {
+    //   when {
+    //     expression {
+    //         !skipRemainingStages
+    //     }
+    //   }
+    //   environment {
+    //     PASSWORD = credentials('amazeeiojenkins-dockerhub-password')
+    //   }
+    //   steps {
+    //     retry(3) {
+    //       timeout(time: 30, unit: 'MINUTES') {
+    //         sh script: "make -j$NPROC -O build PLATFORM_ARCH=linux/arm64", label: "Building arm images"
+    //       }
+    //     }
+    //     retry(3) {
+    //       sh script: 'docker login -u amazeeiojenkins -p $PASSWORD', label: "Docker login"
+    //       sh script: "timeout 12m make -O publish-testlagoon-images PUBLISH_PLATFORM_ARCH=linux/arm64 BRANCH_NAME=${SAFEBRANCH_NAME}", label: "Publishing built arm64 images to testlagoon/*"
+    //       sh script: "timeout 12m make -O publish-testlagoon-images PUBLISH_PLATFORM_ARCH=linux/arm64 BRANCH_NAME=latest", label: "Publishing built arm64 images with :latest tag"
+    //     }
+    //   }
+    // }
     stage ('push images to uselagoon/*') {
       when {
         buildingTag()


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

Something changed in our Jenkins pipeline that makes the ARM images builds take longer than the current 30m (3 retires) limit. Even testing with 1.5hrs x 2, it's not finishing in time. This PR disables ARM image builds until this is resolved or (more likely) we move to github actions.

This mostly affects users with ARM based computers doing local development.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

n/a
