### PR TITLE
chore: avoid qemu for certain image build phases

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -192,7 +192,7 @@ pipeline {
       }
       steps {
         retry(3) {
-          timeout(time: 30, unit: 'MINUTES') {
+          timeout(time: 15, unit: 'MINUTES') {
             sh script: "make -j$NPROC -O build PLATFORM_ARCH=linux/arm64", label: "Building arm images"
           }
         }

--- a/services/actions-handler/Dockerfile
+++ b/services/actions-handler/Dockerfile
@@ -1,13 +1,16 @@
 # build the binary
 ARG UPSTREAM_REPO
 ARG UPSTREAM_TAG
-FROM golang:1.25-alpine3.22 AS builder
+FROM --platform=linux/amd64 golang:1.25-alpine3.22 AS builder
 # bring in all the packages
 COPY . /go/src/github.com/uselagoon/lagoon/services/actions-handler/
 WORKDIR /go/src/github.com/uselagoon/lagoon/services/actions-handler/
 
 # compile
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -o actions-handler .
+ARG TARGETOS
+ARG TARGETARCH
+
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o actions-handler .
 
 # put the binary into container
 # use the commons image to get entrypoints

--- a/services/api-sidecar-handler/Dockerfile
+++ b/services/api-sidecar-handler/Dockerfile
@@ -1,7 +1,7 @@
 # build the binary
 ARG UPSTREAM_REPO
 ARG UPSTREAM_TAG
-FROM golang:1.26-alpine3.22 AS builder
+FROM --platform=linux/amd64 golang:1.26-alpine3.22 AS builder
 
 WORKDIR /workspace
 COPY go.mod go.mod
@@ -13,7 +13,10 @@ COPY services/api-sidecar-handler/cmd/ services/api-sidecar-handler/cmd/
 COPY services/api-sidecar-handler/internal/server services/api-sidecar-handler/internal/server
 
 # compile
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -o api-sidecar-handler services/api-sidecar-handler/cmd/main.go
+ARG TARGETOS
+ARG TARGETARCH
+
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o api-sidecar-handler services/api-sidecar-handler/cmd/main.go
 
 # put the binary into container
 # use the commons image to get entrypoints

--- a/services/backup-handler/Dockerfile
+++ b/services/backup-handler/Dockerfile
@@ -1,14 +1,17 @@
 # build the binary
 ARG UPSTREAM_REPO
 ARG UPSTREAM_TAG
-FROM golang:1.25-alpine3.22 AS builder
+FROM --platform=linux/amd64 golang:1.25-alpine3.22 AS builder
 
 # bring in all the packages
 COPY . /go/src/github.com/uselagoon/lagoon/services/backup-handler/
 WORKDIR /go/src/github.com/uselagoon/lagoon/services/backup-handler/
 
 # compile
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -o backup-handler .
+ARG TARGETOS
+ARG TARGETARCH
+
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o backup-handler .
 
 # put the binary into container
 # use the commons image to get entrypoints

--- a/services/keycloak/Dockerfile
+++ b/services/keycloak/Dockerfile
@@ -1,5 +1,5 @@
 # Stage: Build the custom token mapper
-FROM maven:3.9.14-eclipse-temurin-21-alpine as builder
+FROM --platform=linux/amd64 maven:3.9.14-eclipse-temurin-21-alpine as builder
 COPY custom-mapper/. .
 RUN mvn clean compile package
 

--- a/services/logs2notifications/Dockerfile
+++ b/services/logs2notifications/Dockerfile
@@ -1,13 +1,16 @@
 # build the binary
 ARG UPSTREAM_REPO
 ARG UPSTREAM_TAG
-FROM golang:1.25-alpine3.22 AS builder
+FROM --platform=linux/amd64 golang:1.25-alpine3.22 AS builder
 # bring in all the packages
 COPY . /go/src/github.com/uselagoon/lagoon/services/logs2notifications/
 WORKDIR /go/src/github.com/uselagoon/lagoon/services/logs2notifications/
 
 # compile
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -o logs2notifications .
+ARG TARGETOS
+ARG TARGETARCH
+
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o logs2notifications .
 
 # put the binary into container
 # use the commons image to get entrypoints

--- a/services/webhook-handler/Dockerfile
+++ b/services/webhook-handler/Dockerfile
@@ -1,7 +1,7 @@
 # build the binary
 ARG UPSTREAM_REPO
 ARG UPSTREAM_TAG
-FROM golang:1.26-alpine3.22 AS builder
+FROM --platform=linux/amd64 golang:1.26-alpine3.22 AS builder
 
 WORKDIR /workspace
 COPY go.mod go.mod
@@ -14,7 +14,10 @@ COPY services/webhook-handler/internal/server services/webhook-handler/internal/
 COPY services/webhook-handler/internal/gitlab services/webhook-handler/internal/gitlab
 
 # compile
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -o webhook-handler services/webhook-handler/cmd/main.go
+ARG TARGETOS
+ARG TARGETARCH
+
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o webhook-handler services/webhook-handler/cmd/main.go
 
 # put the binary into container
 # use the commons image to get entrypoints

--- a/taskimages/activestandby/Dockerfile
+++ b/taskimages/activestandby/Dockerfile
@@ -4,8 +4,11 @@ FROM golang:1.25-alpine3.22 AS builder
 COPY . /go/src/github.com/uselagoon/lagoon/taskimages/activestandby/
 WORKDIR /go/src/github.com/uselagoon/lagoon/taskimages/activestandby/
 
+ARG TARGETOS
+ARG TARGETARCH
+
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -o taskrunner .
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o taskrunner .
 
 # Use distroless as minimal base image to package the binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/taskimages/projectclone/Dockerfile
+++ b/taskimages/projectclone/Dockerfile
@@ -1,11 +1,14 @@
 # Build the binary
-FROM golang:1.25-alpine3.22 AS builder
+FROM --platform=linux/amd64  golang:1.25-alpine3.22 AS builder
 
 COPY . /go/src/github.com/uselagoon/lagoon/taskimages/projectclone/
 WORKDIR /go/src/github.com/uselagoon/lagoon/taskimages/projectclone/
 
+ARG TARGETOS
+ARG TARGETARCH
+
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -o taskrunner .
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o taskrunner .
 
 # Add lagoon-sync - need to test this will work
 FROM golang:1.25-alpine3.22 AS syncer
@@ -14,7 +17,7 @@ RUN apk add --no-cache git
 WORKDIR /go/src/github.com/uselagoon/lagoon-sync
 RUN git clone https://github.com/uselagoon/lagoon-sync.git . && \
     git checkout ${LAGOON_SYNC_GIT_BRANCH} && \
-    CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -o /lagoon-sync
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /lagoon-sync
 
 # Switching to commons image
 FROM ${UPSTREAM_REPO:-uselagoon}/commons:${UPSTREAM_TAG:-latest}


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

Changes some image builds to avoid using QEMU in the build process in Jenkins. This is to try and avoid slow compiling when using QEMU. I changed the retry timeout to 15m to try and also induce failures sooner, since the second attempt usually succeeds within the timeout period

Possible replacement for #4113
