### PR TITLE
adds condition to activeStandby assignment

### DIFF
--- a/internal/events/deploy_pull.go
+++ b/internal/events/deploy_pull.go
@@ -21,7 +21,7 @@ func (e *Events) deployPull(project schema.Project, deployData lagoon.DeployData
 		if env.Name == deployData.UnsafeEnvironmentName {
 			deployTarget = &env.DeployTarget
 		}
-		if project.StandbyProductionEnvironment == deployData.UnsafeEnvironmentName || project.ProductionEnvironment == deployData.UnsafeEnvironmentName {
+		if project.StandbyProductionEnvironment != "" && (project.StandbyProductionEnvironment == deployData.UnsafeEnvironmentName || project.ProductionEnvironment == deployData.UnsafeEnvironmentName) {
 			activeStandby = &env.DeployTarget
 		}
 	}

--- a/internal/events/deploy_push.go
+++ b/internal/events/deploy_push.go
@@ -20,7 +20,7 @@ func (e *Events) deployPush(project schema.Project, deployData lagoon.DeployData
 		if env.Name == deployData.UnsafeEnvironmentName {
 			deployTarget = &env.DeployTarget
 		}
-		if project.StandbyProductionEnvironment == deployData.UnsafeEnvironmentName || project.ProductionEnvironment == deployData.UnsafeEnvironmentName {
+		if project.StandbyProductionEnvironment != "" && (project.StandbyProductionEnvironment == deployData.UnsafeEnvironmentName || project.ProductionEnvironment == deployData.UnsafeEnvironmentName) {
 			activeStandby = &env.DeployTarget
 		}
 	}


### PR DESCRIPTION

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

When deploying in test environments we were coming up against the following in the API
`Error deploying testproject: {"error":"unable to create deploy task: environments must be on same deploytarget"}`

We traced this to an issue in the way the actions handler determines active standby environments, mistakenly considering standard setups with Active/Standby. 

This PR attempts to remedy this.

