### PR TITLE
fix: optimize environmentByKubernetesNamespaceName db queries

### DIFF
--- a/services/api/database/migrations/20270717000000_openshiftprojectname_index.js
+++ b/services/api/database/migrations/20270717000000_openshiftprojectname_index.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function(knex) {
+  return knex.schema.alterTable('environment', (table) => {
+    table.index(['openshift_project_name', 'deleted'], 'openshift_project_name_deleted');
+  })
+};
+
+/**
+* @param { import("knex").Knex } knex
+* @returns { Promise<void> }
+*/
+exports.down = async function(knex) {
+  return knex.schema.alterTable('environment', (table) => {
+    table.dropIndex(['openshift_project_name', 'deleted'], 'openshift_project_name_deleted');
+  })
+};

--- a/services/api/src/resources/environment/resolvers.ts
+++ b/services/api/src/resources/environment/resolvers.ts
@@ -277,7 +277,7 @@ export const getEnvironmentByOpenshiftProjectName: ResolverFn = async (
   { sqlClientPool, hasPermission, adminScopes }
 ) => {
 
-  const rows = await query(sqlClientPool, Sql.selectEnvironmentByOpenshiftProjectName(args.openshiftProjectName));
+  const rows = await query(sqlClientPool, Sql.selectEnvironmentsByOpenshiftProjectName(args.openshiftProjectName));
 
   const withK8s = Helpers(sqlClientPool).aliasOpenshiftToK8s(rows);
   const environment = withK8s[0];
@@ -966,7 +966,7 @@ export const userCanSshToEnvironment: ResolverFn = async (
   const openshiftProjectName =
     args.kubernetesNamespaceName || args.openshiftProjectName;
 
-  const rows = await query(sqlClientPool, Sql.canSshToEnvironment(openshiftProjectName));
+  const rows = await query(sqlClientPool, Sql.selectEnvironmentsByOpenshiftProjectName(openshiftProjectName));
   const withK8s = Helpers(sqlClientPool).aliasOpenshiftToK8s(rows);
   const environment = withK8s[0];
 

--- a/services/api/src/resources/environment/sql.ts
+++ b/services/api/src/resources/environment/sql.ts
@@ -175,18 +175,13 @@ export const Sql = {
         .as('subquery');
       })
       .toString(),
-  selectEnvironmentByOpenshiftProjectName: (openshiftProjectName: string) =>
-    knex('environment AS e')
-      .select('e.*')
-      .join('project', 'e.project', '=', 'project.id')
-      .where(knex.raw('e.openshift_project_name = ?', openshiftProjectName))
-      .andWhere('e.deleted', '0000-00-00 00:00:00')
-      .toString(),
-  canSshToEnvironment: (openshiftProjectName: string) =>
-    knex('environment AS e')
-      .select('e.*')
-      .join('project', 'e.project', '=', 'project.id')
-      .where(knex.raw('e.openshift_project_name = ?', openshiftProjectName))
+  selectEnvironmentsByOpenshiftProjectName: (openshiftProjectName: string) =>
+    knex('environment')
+      .where({
+        'openshift_project_name': openshiftProjectName,
+        'deleted': '0000-00-00 00:00:00',
+      })
+      .orderBy('created', 'desc')
       .toString(),
   selectEnvironmentServiceById: (id: number) =>
     knex('environment_service')


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Database Migrations

- [x] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

The database queries behind the `environmentByKubernetesNamespaceName` api query are poorly optimized and are the bottleneck for performance. In a production Lagoon, a single query can take in excess of four seconds and scan ~36,000 rows.

```sql
explain select `e`.* from `environment` as `e` inner join `project` on `e`.`project` = `project`.`id` where e.openshift_project_name = 'lagoon-demo-org-main' and `e`.`deleted` = '0000-00-00 00:00:00';
+------+-------------+---------+-------+----------------------+----------------------+---------+---------------------------+------+------------------------------------+
| id   | select_type | table   | type  | possible_keys        | key                  | key_len | ref                       | rows | Extra                              |
+------+-------------+---------+-------+----------------------+----------------------+---------+---------------------------+------+------------------------------------+
|    1 | SIMPLE      | project | index | PRIMARY              | name                 | 303     | NULL                      | 4083 | Using index                        |
|    1 | SIMPLE      | e       | ref   | project_name_deleted | project_name_deleted | 5       | infrastructure.project.id | 9    | Using index condition; Using where |
+------+-------------+---------+-------+----------------------+----------------------+---------+---------------------------+------+------------------------------------+
```
The root cause is a missing index on `openshift_project_name`. Additionally, the query joins on the `project` table but doesn't select or filter by any of its fields. Only removing the `project` join would fix the performance problem because "only" a table scan of the `environment` table is needed, and the table is relatively small.

This PR adds an index for `openshift_project_name`+`deleted` and fixes the query to use only the data that's required. In production this query now runs in milliseconds.

Edit:

Adding the index can change the ordering for queries that don't have an explicit `ORDER BY` clause. In cases where there are multiple environments with the same `openshift_project_name`, the "wrong" environment may be returned, which would show incorrect data in dashboard or prevent SSH connections.

As this is an edge case brought on by manual data manipulation (eg, migrating projects between clusters), the short term fix is to explicitly order by environment created date. This is closer to the implicit ordering happening pre-index.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

n/a
