### PR TITLE
feat: log api-db/keycloak-db slow queries to stdout

### DIFF
--- a/services/api-db/Dockerfile
+++ b/services/api-db/Dockerfile
@@ -7,8 +7,11 @@ ENV LAGOON_VERSION=$LAGOON_VERSION
 
 USER root
 
+RUN /bin/fix-permissions /var/log/
+
 # replace the generate-env script with our password, since generate-env only adds a domain which isnt valid in this image
 COPY password-entrypoint.bash /lagoon/entrypoints/55-generate-env.sh
+COPY slow-query-stdout-entrypoint.bash /lagoon/entrypoints/101-slow-query-stdout.sh
 
 USER mysql
 

--- a/services/api-db/Dockerfile.mysql
+++ b/services/api-db/Dockerfile.mysql
@@ -7,8 +7,11 @@ ENV LAGOON_VERSION=$LAGOON_VERSION
 
 USER root
 
+RUN /bin/fix-permissions /var/log/
+
 # replace the generate-env script with our password, since generate-env only adds a domain which isnt valid in this image
 COPY password-entrypoint.bash /lagoon/entrypoints/55-generate-env.sh
+COPY slow-query-stdout-mysql-entrypoint.bash /lagoon/entrypoints/101-slow-query-stdout.sh
 
 USER mysql
 

--- a/services/api-db/slow-query-stdout-entrypoint.bash
+++ b/services/api-db/slow-query-stdout-entrypoint.bash
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+if [ -n "$MARIADB_LOG_SLOW" ]; then
+  # Log slow queries to stdout
+  ln -sf /proc/1/fd/1 /var/log/mariadb-slow.log
+fi

--- a/services/api-db/slow-query-stdout-mysql-entrypoint.bash
+++ b/services/api-db/slow-query-stdout-mysql-entrypoint.bash
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+if [ -n "$MYSQL_LOG_SLOW" ]; then
+  # Log slow queries to stdout
+  ln -sf /proc/1/fd/1 /var/log/mysql-slow.log
+fi

--- a/services/keycloak-db/Dockerfile
+++ b/services/keycloak-db/Dockerfile
@@ -13,7 +13,9 @@ ENV MARIADB_DATABASE=keycloak \
 
 COPY my_query-cache.cnf /etc/mysql/conf.d/my_query-cache.cnf
 USER root
+RUN /bin/fix-permissions /var/log/
 # replace the generate-env script with our password, since generate-env only adds a domain which isnt valid in this image
 COPY password-entrypoint.bash /lagoon/entrypoints/55-generate-env.sh
+COPY slow-query-stdout-entrypoint.bash /lagoon/entrypoints/101-slow-query-stdout.sh
 RUN fix-permissions /etc/mysql/conf.d/
 USER mysql

--- a/services/keycloak-db/Dockerfile.mysql
+++ b/services/keycloak-db/Dockerfile.mysql
@@ -13,8 +13,10 @@ ENV MYSQL_DATABASE=keycloak \
     # MYSQL_COLLATION=utf8_general_ci
 
 USER root
+RUN /bin/fix-permissions /var/log/
 # replace the generate-env script with our password, since generate-env only adds a domain which isnt valid in this image
 COPY password-entrypoint.bash /lagoon/entrypoints/55-generate-env.sh
+COPY slow-query-stdout-mysql-entrypoint.bash /lagoon/entrypoints/101-slow-query-stdout.sh
 USER mysql
 
 # not used in mysql8

--- a/services/keycloak-db/slow-query-stdout-entrypoint.bash
+++ b/services/keycloak-db/slow-query-stdout-entrypoint.bash
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+if [ -n "$MARIADB_LOG_SLOW" ]; then
+  # Log slow queries to stdout
+  ln -sf /proc/1/fd/1 /var/log/mariadb-slow.log
+fi

--- a/services/keycloak-db/slow-query-stdout-mysql-entrypoint.bash
+++ b/services/keycloak-db/slow-query-stdout-mysql-entrypoint.bash
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+if [ -n "$MYSQL_LOG_SLOW" ]; then
+  # Log slow queries to stdout
+  ln -sf /proc/1/fd/1 /var/log/mysql-slow.log
+fi


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Database Migrations

n/a

# Description

The default for Lagoon db images is to log queries to `/var/log` which is not persistent and does not prevent endless growth.

This PR configures the slow query log (when enabled) to print to `stdout` so that they can be ingested by normal container log methods.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

n/a
