### PR TITLE
fix: make sure pr number is number in payload

### DIFF
--- a/node-packages/commons/src/types.ts
+++ b/node-packages/commons/src/types.ts
@@ -99,7 +99,7 @@ export interface DeployData {
 
 export interface DeployPullrequest {
   title: string,
-  number: string,
+  number: number,
   headBranch: string,
   headSha: string,
   baseBranch: string,

--- a/services/api/src/resources/deployment/resolvers.ts
+++ b/services/api/src/resources/deployment/resolvers.ts
@@ -851,7 +851,7 @@ export const deployEnvironmentLatest: ResolverFn = async (
       }
       let pullrequest: DeployPullrequest = {
         title: environment.deployTitle,
-        number: environment.name.replace('pr-', ''),
+        number: parseInt(environment.name.replace('pr-', '')),
         headBranch: environment.deployHeadRef,
         headSha: `origin/${environment.deployHeadRef}`,
         baseBranch: environment.deployBaseRef,
@@ -1198,7 +1198,7 @@ export const deployEnvironmentPullrequest: ResolverFn = async (
   }
   const pullrequest: DeployPullrequest = {
     title: title,
-    number: number,
+    number: parseInt(number),
     headBranch: headBranchName,
     headSha: headBranchRef,
     baseBranch: baseBranchName,


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

The payload to send PR data to the sidecar was incorrectly setting the PR number as a string, when it should be an integer.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

