### PR TITLE
fix: delete environment logic checks

### DIFF
--- a/internal/events/deploy_pull.go
+++ b/internal/events/deploy_pull.go
@@ -80,7 +80,7 @@ func (e *Events) deployPull(project schema.Project, deployData lagoon.DeployData
 					e.Messaging.SendToLagoonTasks(fmt.Sprintf("%s:builddeploy", deployData.DeployTarget.Name), lagoon.BuildToBytes(buildData))
 					return lagoon.BuildToBytes(buildData), nil
 				} else {
-					errs = append(errs, fmt.Sprintf("deployment not allowed on deploytargetg %s didn't match pullrequest title regex pattern for deploytargetconfig", dtc.DeployTarget.Name))
+					errs = append(errs, fmt.Sprintf("deployment not allowed on deploytarget %s didn't match pullrequest title regex pattern for deploytargetconfig", dtc.DeployTarget.Name))
 					continue
 				}
 			}

--- a/internal/events/deploy_pull.go
+++ b/internal/events/deploy_pull.go
@@ -66,7 +66,7 @@ func (e *Events) deployPull(project schema.Project, deployData lagoon.DeployData
 				e.Messaging.SendToLagoonTasks(fmt.Sprintf("%s:builddeploy", deployData.DeployTarget.Name), lagoon.BuildToBytes(buildData))
 				return lagoon.BuildToBytes(buildData), nil
 			case "false":
-				errs = append(errs, fmt.Sprintf("deployment not allowed on deploytargetconfig %s pullrequests disabled", dtc.DeployTarget.Name))
+				errs = append(errs, fmt.Sprintf("deployment not allowed on deploytarget %s pullrequests disabled", dtc.DeployTarget.Name))
 				continue
 			default:
 				re := regexp2.MustCompile(dtc.Pullrequests, 0)
@@ -80,7 +80,7 @@ func (e *Events) deployPull(project schema.Project, deployData lagoon.DeployData
 					e.Messaging.SendToLagoonTasks(fmt.Sprintf("%s:builddeploy", deployData.DeployTarget.Name), lagoon.BuildToBytes(buildData))
 					return lagoon.BuildToBytes(buildData), nil
 				} else {
-					errs = append(errs, fmt.Sprintf("deployment not allowed on deploytargetconfig %s didn't match pullrequest title regex pattern for deploytargetconfig", dtc.DeployTarget.Name))
+					errs = append(errs, fmt.Sprintf("deployment not allowed on deploytargetg %s didn't match pullrequest title regex pattern for deploytargetconfig", dtc.DeployTarget.Name))
 					continue
 				}
 			}

--- a/internal/events/deploy_push.go
+++ b/internal/events/deploy_push.go
@@ -57,7 +57,7 @@ func (e *Events) deployPush(project schema.Project, deployData lagoon.DeployData
 				e.Messaging.SendToLagoonTasks(fmt.Sprintf("%s:builddeploy", deployData.DeployTarget.Name), lagoon.BuildToBytes(buildData))
 				return lagoon.BuildToBytes(buildData), nil
 			case "false":
-				errs = append(errs, fmt.Sprintf("deployment not allowed on deploytargetconfig %s branches disabled", dtc.DeployTarget.Name))
+				errs = append(errs, fmt.Sprintf("deployment not allowed on deploytarget %s branches disabled", dtc.DeployTarget.Name))
 				continue
 			default:
 				re := regexp2.MustCompile(dtc.Branches, 0)
@@ -71,7 +71,7 @@ func (e *Events) deployPush(project schema.Project, deployData lagoon.DeployData
 					e.Messaging.SendToLagoonTasks(fmt.Sprintf("%s:builddeploy", deployData.DeployTarget.Name), lagoon.BuildToBytes(buildData))
 					return lagoon.BuildToBytes(buildData), nil
 				} else {
-					errs = append(errs, fmt.Sprintf("deployment not allowed on deploytargetconfig %s didn't match branches regex pattern for deploytargetconfig", dtc.DeployTarget.Name))
+					errs = append(errs, fmt.Sprintf("deployment not allowed on deploytarget %s didn't match branches regex pattern for deploytargetconfig", dtc.DeployTarget.Name))
 					continue
 				}
 			}

--- a/services/api-sidecar-handler/internal/server/remove.go
+++ b/services/api-sidecar-handler/internal/server/remove.go
@@ -23,10 +23,6 @@ func (s *Server) removeEnvironment(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	if !fdpe {
-		log.Printf("%s is defined as the production environment for %s, refusing to remove.", environmentName, projectName)
-		return
-	}
 	e := events.New(s.LagoonAPI, s.Messaging)
 	project, err := e.LagoonAPI.ProjectByName(projectName)
 	if err != nil {

--- a/services/api/src/resources/deployment/resolvers.ts
+++ b/services/api/src/resources/deployment/resolvers.ts
@@ -935,8 +935,9 @@ export const deployEnvironmentLatest: ResolverFn = async (
     );
     if (!response.ok) {
       const errorText = await response.text();
+      const errJSON = JSON.parse(errorText)
       logger.error(`Error deploying ${environment.name}: ${errorText}`)
-      throw new Error(`Error deploying ${environment.name}`);
+      throw new Error(`Error deploying ${environment.name}: ${errJSON.error}`);
     }
 
     sendToLagoonLogs(
@@ -1092,8 +1093,9 @@ export async function deployBranch(returnData, project, branchName, branchRef, p
     );
     if (!response.ok) {
       const errorText = await response.text();
+      const errJSON = JSON.parse(errorText)
       logger.error(`Error deploying ${deployData.branchName}: ${errorText}`)
-      throw new Error(`Error deploying ${deployData.branchName}`);
+      throw new Error(`Error deploying ${deployData.branchName}: ${errJSON.error}`);
     }
 
     sendToLagoonLogs(
@@ -1256,8 +1258,9 @@ export const deployEnvironmentPullrequest: ResolverFn = async (
     );
     if (!response.ok) {
       const errorText = await response.text();
+      const errJSON = JSON.parse(errorText)
       logger.error(`Error deploying ${deployData.branchName}: ${errorText}`)
-      throw new Error(`Error deploying ${deployData.branchName}`);
+      throw new Error(`Error deploying ${deployData.branchName}: ${errJSON.error}`);
     }
 
     sendToLagoonLogs(
@@ -1430,8 +1433,9 @@ export const deployEnvironmentPromote: ResolverFn = async (
     );
     if (!response.ok) {
       const errorText = await response.text();
+      const errJSON = JSON.parse(errorText)
       logger.error(`Error deploying ${deployData.branchName}: ${errorText}`)
-      throw new Error(`Error deploying ${deployData.branchName}`);
+      throw new Error(`Error deploying ${deployData.branchName}: ${errJSON.error}`);
     }
 
     sendToLagoonLogs(

--- a/services/api/src/resources/deployment/resolvers.ts
+++ b/services/api/src/resources/deployment/resolvers.ts
@@ -58,6 +58,14 @@ const s3Client = new S3Client({
 
 const convertDateFormat = R.init;
 
+export function safeParse(str) {
+  try {
+    return JSON.parse(str)
+  } catch {
+    return null
+  }
+}
+
 export const getBuildLog: ResolverFn = async (
   { remoteId, environment, name, status },
   _args,
@@ -935,9 +943,9 @@ export const deployEnvironmentLatest: ResolverFn = async (
     );
     if (!response.ok) {
       const errorText = await response.text();
-      const errJSON = JSON.parse(errorText)
-      logger.error(`Error deploying ${environment.name}: ${errorText}`)
-      throw new Error(`Error deploying ${environment.name}: ${errJSON.error}`);
+      const message = safeParse(errorText)?.error ?? errorText ?? 'Unknown error'
+      logger.error(`Error deploying ${environment.name}: ${message}`)
+      throw new Error(`Error deploying ${environment.name}: ${message}`)
     }
 
     sendToLagoonLogs(
@@ -1093,9 +1101,9 @@ export async function deployBranch(returnData, project, branchName, branchRef, p
     );
     if (!response.ok) {
       const errorText = await response.text();
-      const errJSON = JSON.parse(errorText)
-      logger.error(`Error deploying ${deployData.branchName}: ${errorText}`)
-      throw new Error(`Error deploying ${deployData.branchName}: ${errJSON.error}`);
+      const message = safeParse(errorText)?.error ?? errorText ?? 'Unknown error'
+      logger.error(`Error deploying ${deployData.branchName}: ${message}`)
+      throw new Error(`Error deploying ${deployData.branchName}: ${message}`)
     }
 
     sendToLagoonLogs(
@@ -1258,9 +1266,9 @@ export const deployEnvironmentPullrequest: ResolverFn = async (
     );
     if (!response.ok) {
       const errorText = await response.text();
-      const errJSON = JSON.parse(errorText)
-      logger.error(`Error deploying ${deployData.branchName}: ${errorText}`)
-      throw new Error(`Error deploying ${deployData.branchName}: ${errJSON.error}`);
+      const message = safeParse(errorText)?.error ?? errorText ?? 'Unknown error'
+      logger.error(`Error deploying ${deployData.branchName}: ${message}`)
+      throw new Error(`Error deploying ${deployData.branchName}: ${message}`)
     }
 
     sendToLagoonLogs(
@@ -1433,9 +1441,9 @@ export const deployEnvironmentPromote: ResolverFn = async (
     );
     if (!response.ok) {
       const errorText = await response.text();
-      const errJSON = JSON.parse(errorText)
-      logger.error(`Error deploying ${deployData.branchName}: ${errorText}`)
-      throw new Error(`Error deploying ${deployData.branchName}: ${errJSON.error}`);
+      const message = safeParse(errorText)?.error ?? errorText ?? 'Unknown error'
+      logger.error(`Error deploying ${deployData.branchName}: ${message}`)
+      throw new Error(`Error deploying ${deployData.branchName}: ${message}`)
     }
 
     sendToLagoonLogs(

--- a/services/api/src/resources/environment/resolvers.ts
+++ b/services/api/src/resources/environment/resolvers.ts
@@ -637,18 +637,16 @@ export const deleteEnvironment: ResolverFn = async (
     );
   }
 
+  let canDeleteProduction = false;
   await hasPermission('environment', `delete:${environment.environmentType}`, {
     project: projectId
   });
-
-  let canDeleteProduction;
-  try {
-    await hasPermission('environment', 'delete:production', {
-      project: projectId
-    });
+  // rather than do a second permission check specifically for production
+  // if the permission check above succeeds on `production` types
+  // just set the value if the environment type is production
+  // the permission check above will fail before this if the user doesn't have permission to do this action anyway
+  if (environment.environmentType == "production") {
     canDeleteProduction = true;
-  } catch (err) {
-    canDeleteProduction = false;
   }
 
   let removeData: RemoveData = {

--- a/services/api/src/resources/environment/resolvers.ts
+++ b/services/api/src/resources/environment/resolvers.ts
@@ -645,7 +645,7 @@ export const deleteEnvironment: ResolverFn = async (
   // if the permission check above succeeds on `production` types
   // just set the value if the environment type is production
   // the permission check above will fail before this if the user doesn't have permission to do this action anyway
-  if (environment.environmentType == "production") {
+  if (environment.environmentType === "production") {
     canDeleteProduction = true;
   }
 


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

Fix to the logic to delete environment logic in the sidecar handler to ignore. Previously, the check in the sidecar handler would fail if a user with a role that didn't have permission to delete production environments would be blocked from deleting any environment.

Also adjusts some logs and errors to include better information for generated errors to expose better failures
