### PR TITLE
fix: only send git notification for valid matches

### DIFF
--- a/internal/events/event_branch.go
+++ b/internal/events/event_branch.go
@@ -87,11 +87,12 @@ func (e *Events) HandleBranch(gitType, event, uuid string, scmWebhook *scm.Branc
 			}
 			resp, err = e.CreateDeployTask(project, deployData)
 		}
-		// send the message to lagoon-logs to be handled by notifications
-		e.Messaging.SendToLagoonLogs(uuid, project.Name, handledEvent, meta)
 		if err != nil {
 			errs++
 			response.Error = err
+		} else {
+			// send the message to lagoon-logs to be handled by notifications
+			e.Messaging.SendToLagoonLogs(uuid, project.Name, handledEvent, meta)
 		}
 		response.Response = string(resp)
 		resps = append(resps, response)

--- a/internal/events/event_pull.go
+++ b/internal/events/event_pull.go
@@ -94,11 +94,12 @@ func (e *Events) HandlePull(gitType, event, uuid string, scmWebhook *scm.PullReq
 			RepoName:          fmt.Sprintf("%s/%s", scmWebhook.Repo.Namespace, scmWebhook.Repo.Name),
 			RepoURL:           scmWebhook.Repo.Link,
 		}
-		// send the message to lagoon-logs to be handled by notifications
-		e.Messaging.SendToLagoonLogs(uuid, project.Name, handledEvent, pullmeta)
 		if err != nil {
 			errs++
 			response.Error = err
+		} else {
+			// send the message to lagoon-logs to be handled by notifications
+			e.Messaging.SendToLagoonLogs(uuid, project.Name, handledEvent, pullmeta)
 		}
 		response.Response = string(resp)
 		resps = append(resps, response)

--- a/internal/events/event_push.go
+++ b/internal/events/event_push.go
@@ -107,7 +107,9 @@ func (e *Events) HandlePush(gitType, event, uuid string, scmWebhook *scm.PushHoo
 				pushmeta.ShortSHA = scmWebhook.Commit.Sha
 			}
 			// send the message to lagoon-logs to be handled by notifications
-			e.Messaging.SendToLagoonLogs(uuid, project.Name, handledEvent, pushmeta)
+			if err == nil {
+				e.Messaging.SendToLagoonLogs(uuid, project.Name, handledEvent, pushmeta)
+			}
 		}
 		if err != nil {
 			errs++


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migation, it **MUST** be the latest in date order alphabetically

# Description

Small adjustment after #4134 to only send notifications if a deploy task is successful. This means branches that do not match the regex will not send notifications. It also means that failures to create the deployment will not send the notification either without refactoring the error handling more to be failure case aware. This could be done in a follow up refactor though.

If notifications had more flexibility or options for users to select, some improvements to notifications could be to include failures for deployments based on the reasons for their failure (not matching regex, exceeding limits, etc). But this is too complicated to implement at the moment due to notifications being fairly basic