### PR TITLE
refactor/fix: webhook 200s with fixed envtype checks

### DIFF
--- a/internal/events/deploy.go
+++ b/internal/events/deploy.go
@@ -50,7 +50,7 @@ func (e *Events) CreateDeployTask(project schema.Project, deployData lagoon.Depl
 	} else {
 		devEnvs := []schema.EnvironmentConfig{}
 		for _, env := range project.Environments {
-			if env.EnvironmentType == schema.DevelopmentEnv {
+			if string(env.EnvironmentType) == strings.ToLower(string(schema.DevelopmentEnv)) {
 				devEnvs = append(devEnvs, env)
 			}
 		}

--- a/services/webhook-handler/internal/server/server.go
+++ b/services/webhook-handler/internal/server/server.go
@@ -181,7 +181,9 @@ func (s *Server) handleWebhookPost(w http.ResponseWriter, r *http.Request) {
 				response, err = e.HandlePull(gitType, event, reqUUID, scmWebhook)
 			case *scm.TagHook:
 				// future?
-				respondWithError(w, http.StatusBadRequest, "tags events are currently unsupported")
+				// respond with 200 code, even though this is an error
+				// this is to prevent some git solutions from disabling webhooks
+				respondWithJSON(w, http.StatusOK, map[string]string{"error": "tags events are currently unsupported"})
 				return
 			}
 			if err != nil {
@@ -196,7 +198,9 @@ func (s *Server) handleWebhookPost(w http.ResponseWriter, r *http.Request) {
 				} else {
 					log.Println("Error:", err)
 				}
-				respondWithError(w, http.StatusBadRequest, "invalid resquest payload")
+				// respond with 200 code, even though this is an error
+				// this is to prevent some git solutions from disabling webhooks
+				respondWithJSON(w, http.StatusOK, map[string]string{"error": "invalid resquest payload"})
 				return
 			}
 			if s.VerboseResponse {

--- a/services/webhook-handler/internal/server/server_test.go
+++ b/services/webhook-handler/internal/server/server_test.go
@@ -51,7 +51,7 @@ func TestWebhookEvents(t *testing.T) {
 			gitType:      "github",
 			event:        "push",
 			webhook:      "github/push-skipped",
-			wantCode:     400,
+			wantCode:     200,
 			wantResponse: "invalid.json",
 		},
 		{
@@ -67,7 +67,7 @@ func TestWebhookEvents(t *testing.T) {
 			gitType:      "github",
 			event:        "push",
 			webhook:      "github/push-delete-prod",
-			wantCode:     400,
+			wantCode:     200,
 			wantResponse: "invalid.json",
 		},
 		{
@@ -99,7 +99,7 @@ func TestWebhookEvents(t *testing.T) {
 			gitType:      "github",
 			event:        "pull_request",
 			webhook:      "github/pr-open-skip",
-			wantCode:     400,
+			wantCode:     200,
 			wantResponse: "invalid.json",
 		},
 		{
@@ -148,7 +148,7 @@ func TestWebhookEvents(t *testing.T) {
 			gitType:      "gitlab",
 			event:        "Push Hook",
 			webhook:      "gitlab/push-skipped",
-			wantCode:     400,
+			wantCode:     200,
 			wantResponse: "invalid.json",
 		},
 		{
@@ -164,7 +164,7 @@ func TestWebhookEvents(t *testing.T) {
 			gitType:      "gitlab",
 			event:        "Push Hook",
 			webhook:      "gitlab/push-delete-prod",
-			wantCode:     400,
+			wantCode:     200,
 			wantResponse: "invalid.json",
 		},
 		{
@@ -188,7 +188,7 @@ func TestWebhookEvents(t *testing.T) {
 			gitType:      "gitlab",
 			event:        "Merge Request Hook",
 			webhook:      "gitlab/pr-open-skip",
-			wantCode:     400,
+			wantCode:     200,
 			wantResponse: "invalid.json",
 		},
 		{
@@ -237,7 +237,7 @@ func TestWebhookEvents(t *testing.T) {
 			gitType:      "gitea",
 			event:        "push",
 			webhook:      "gitea/push-skipped",
-			wantCode:     400,
+			wantCode:     200,
 			wantResponse: "invalid.json",
 		},
 		{
@@ -253,7 +253,7 @@ func TestWebhookEvents(t *testing.T) {
 			gitType:      "gitea",
 			event:        "delete",
 			webhook:      "gitea/branch-delete-prod",
-			wantCode:     400,
+			wantCode:     200,
 			wantResponse: "invalid.json",
 		},
 		{
@@ -269,7 +269,7 @@ func TestWebhookEvents(t *testing.T) {
 			gitType:      "gitea",
 			event:        "pull_request",
 			webhook:      "gitea/pr-open-skip",
-			wantCode:     400,
+			wantCode:     200,
 			wantResponse: "invalid.json",
 		},
 		{
@@ -310,7 +310,7 @@ func TestWebhookEvents(t *testing.T) {
 			gitType:      "stash",
 			event:        "repo:refs_changed",
 			webhook:      "stash/push-skipped",
-			wantCode:     400,
+			wantCode:     200,
 			wantResponse: "invalid.json",
 		},
 		{
@@ -326,7 +326,7 @@ func TestWebhookEvents(t *testing.T) {
 			gitType:      "stash",
 			event:        "repo:refs_changed",
 			webhook:      "stash/push-delete-prod",
-			wantCode:     400,
+			wantCode:     200,
 			wantResponse: "invalid.json",
 		},
 		{
@@ -350,7 +350,7 @@ func TestWebhookEvents(t *testing.T) {
 			gitType:      "stash",
 			event:        "pr:opened",
 			webhook:      "stash/pr-open-skip",
-			wantCode:     400,
+			wantCode:     200,
 			wantResponse: "invalid.json",
 		},
 		{
@@ -391,7 +391,7 @@ func TestWebhookEvents(t *testing.T) {
 			gitType:      "gogs",
 			event:        "push",
 			webhook:      "gogs/push-skipped",
-			wantCode:     400,
+			wantCode:     200,
 			wantResponse: "invalid.json",
 		},
 		{
@@ -407,7 +407,7 @@ func TestWebhookEvents(t *testing.T) {
 			gitType:      "gogs",
 			event:        "delete",
 			webhook:      "gogs/branch-delete-prod",
-			wantCode:     400,
+			wantCode:     200,
 			wantResponse: "invalid.json",
 		},
 		{
@@ -423,7 +423,7 @@ func TestWebhookEvents(t *testing.T) {
 			gitType:      "gogs",
 			event:        "pull_request",
 			webhook:      "gogs/pr-open-skip",
-			wantCode:     400,
+			wantCode:     200,
 			wantResponse: "invalid.json",
 		},
 		{
@@ -464,7 +464,7 @@ func TestWebhookEvents(t *testing.T) {
 			gitType:      "bitbucket",
 			event:        "repo:push",
 			webhook:      "bitbucket/push-skipped",
-			wantCode:     400,
+			wantCode:     200,
 			wantResponse: "invalid.json",
 		},
 		{
@@ -480,7 +480,7 @@ func TestWebhookEvents(t *testing.T) {
 			gitType:      "bitbucket",
 			event:        "repo:push",
 			webhook:      "bitbucket/push-delete-prod",
-			wantCode:     400,
+			wantCode:     200,
 			wantResponse: "invalid.json",
 		},
 		{
@@ -512,7 +512,7 @@ func TestWebhookEvents(t *testing.T) {
 			gitType:      "bitbucket",
 			event:        "pullrequest:created",
 			webhook:      "bitbucket/pr-open-skip",
-			wantCode:     400,
+			wantCode:     200,
 			wantResponse: "invalid.json",
 		},
 		{


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migration, it **MUST** be the latest in date order alphabetically

# Description

Some git hosting providers will disable webhooks if they receive too many errors. This changes the error code to 200s for all webhooks.

This is done because some webhooks would previously return a 400 indicating a failure to deploy. Previous webhook-handler in Lagoon also responded with 200s for all webhooks, so this is returning to that previous behaviour.

Additionally fixes an environment type check when deploying