### PR TITLE
Serve pages as Markdown and publish llms.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,4 @@ mkdocs-git-revision-date-localized-plugin
 mkdocs-awesome-pages-plugin
 mkdocs-markdownextradata-plugin
 mkdocs-static-i18n
+mkdocs-llms-source

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -238,6 +238,10 @@ plugins:
       lang:
       - en
       - ja
+  - llms-source:
+      description: >-
+        Documentation for Lagoon, the open source application delivery
+        platform for Kubernetes.
   - awesome-pages
   - markdownextradata: {}
   - i18n:


### PR DESCRIPTION
Publishes each docs page as plain Markdown alongside the HTML, plus an
llms.txt index, so AI tools can read the docs directly instead of scraping.

Two small changes: the plugin in docs/requirements.txt (unpinned, matching
the other entries) and enabled in mkdocs.yml.

Checked with a strict build both ways — the native build that publishes the
site, and the container check in CI. The Japanese site still builds and
needs no translation changes, since this adds nothing to the nav.

CI's container step will fail until the plugin lands in the mkdocs-material
image. The native build, which is what publishes, passes now.

