### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/services/api/src/clients/aws.ts
+++ b/services/api/src/clients/aws.ts
@@ -3,8 +3,8 @@ import { getConfigFromEnv } from '../util/config';
 
 export const config = {
   origin: getConfigFromEnv('S3_FILES_HOST', 'http://docker.for.mac.localhost:9000'),
-  accessKeyId: getConfigFromEnv('S3_FILES_ACCESS_KEY_ID', 'minio'),
-  secretAccessKey: getConfigFromEnv('S3_FILES_SECRET_ACCESS_KEY', 'minio123'),
+  accessKeyId: getConfigFromEnv('S3_FILES_ACCESS_KEY_ID'),
+  secretAccessKey: getConfigFromEnv('S3_FILES_SECRET_ACCESS_KEY'),
   region: getConfigFromEnv('S3_FILES_REGION', 'us-east-1'),
   bucket: getConfigFromEnv('S3_FILES_BUCKET', 'lagoon-files')
 };

--- a/services/api/src/clients/esClient.ts
+++ b/services/api/src/clients/esClient.ts
@@ -4,7 +4,7 @@ import { getConfigFromEnv } from '../util/config';
 export const config = {
   host: getConfigFromEnv('ELASTICSEARCH_URL', 'http://logs-db-service:9200'),
   user: 'admin',
-  pass: getConfigFromEnv('LOGSDB_ADMIN_PASSWORD', '<password not set>')
+  pass: getConfigFromEnv('LOGSDB_ADMIN_PASSWORD')
 };
 
 export const esClient = new Client({


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `services/api/src/clients/aws.ts:L7`

The AWS S3 client configuration uses hardcoded default credentials ('minio' / 'minio123'). If the environment variables `S3_FILES_ACCESS_KEY_ID` and `S3_FILES_SECRET_ACCESS_KEY` are not explicitly set, the application will silently fall back to these default credentials, potentially allowing unauthorized access to the file storage backend.

## Solution

Remove the hardcoded default credentials. If the environment variables are not set, the application should throw a configuration error and halt startup rather than falling back to insecure defaults.

## Changes

- `services/api/src/clients/aws.ts` (modified)
- `services/api/src/clients/esClient.ts` (modified)