### PR TITLE
fix: reject ssh usernames that can't map to a namespace

### DIFF
--- a/services/ssh/authorize.sh
+++ b/services/ssh/authorize.sh
@@ -20,6 +20,10 @@ api=$API_HOST
 ssh_username=$1
 ssh_fingerprint=$2
 
+if [[ ! "$ssh_username" =~ ^[A-Za-z0-9-]+$ ]]; then
+    exit 1
+fi
+
 data="{\"fingerprint\": \"$ssh_fingerprint\"}"
 keys=$(wget --header "Content-Type: application/json" --header "$bearer" $api/keys --post-data "$data" -q --content-on-error -O -)
 


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Database Migrations

n/a

# Description

Fixes an issue where special characters in an ssh username could lead to undefined behavior.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

n/a
