### PR TITLE
fix: remove image from msteams notifications

### DIFF
--- a/services/logs2notifications/internal/handler/microsoftteams_events.go
+++ b/services/logs2notifications/internal/handler/microsoftteams_events.go
@@ -23,8 +23,7 @@ type MicrosoftTeamsData struct {
 
 // MicrosoftTeamsSection .
 type MicrosoftTeamsSection struct {
-	ActivityText  string `json:"activityText"`
-	ActivityImage string `json:"activityImage"`
+	ActivityText string `json:"activityText"`
 }
 
 // SendToMicrosoftTeams .
@@ -118,9 +117,6 @@ func (h *Messaging) sendMicrosoftTeamsMessage(emoji, color, webhook, event, proj
 		Sections: []MicrosoftTeamsSection{
 			{
 				ActivityText: message,
-				// This doesn't work in teams apparently, removing for now
-				// 'Post_card_in_a_chat_or_channel_1' failed: Invalid image URI
-				// ActivityImage: emoji,
 			},
 		},
 	}


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migration, it **MUST** be the latest in date order alphabetically

# Description

Removes the `ActivityImage` from the struct to prevent it sending an empty string

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

