### PR TITLE
Change: Clone cancel cleanup

### DIFF
--- a/services/api/src/resources/project/resolvers.ts
+++ b/services/api/src/resources/project/resolvers.ts
@@ -1781,6 +1781,9 @@ export const cancelProjectClone: ResolverFn = async (
     pubSub.publish(EVENTS.ORGPROJECT, destProject);
   }
 
+  const restrictions = ['no_deployments','no_tasks','no_project_variables','no_environment_variables']
+  await Helpers(sqlClientPool).removeProjectRestrictions(destProject.id, restrictions);
+
   if (cleanupClone) {
     await deleteFilesForProjectClone(root, { input: { id: cloneId } }, { sqlClientPool, hasPermission, userActivityLogger, models, adminScopes, keycloakGrant, legacyGrant });
 

--- a/services/api/src/resources/project/resolvers.ts
+++ b/services/api/src/resources/project/resolvers.ts
@@ -1232,16 +1232,16 @@ export const cloneProject: ResolverFn = async (
     }
 
 // check if environment exists + at least one successful deployment
-//   const latestDeployment = await query(sqlClientPool, deploymentSql.selectLatestDeploymentForEnvironment(environmentData.id));
-//   if (latestDeployment && latestDeployment[0]?.status !== 'complete') {
-//     throw new Error('The source environment must have at least one successful deployment');
-//   }
+  const latestDeployment = await query(sqlClientPool, deploymentSql.selectLatestDeploymentForEnvironment(environmentData.id));
+  if (latestDeployment && latestDeployment[0]?.status !== 'complete') {
+    throw new Error('The source environment must have at least one successful deployment');
+  }
 
-// // check if the project has deploytarget configurations - not currently supported for cloning
-//   const deployTargetConfigs = await query(sqlClientPool, deployTargetConfigSql.selectDeployTargetConfigsByProjectId(sourceProject.id));
-//   if (deployTargetConfigs && deployTargetConfigs.length > 0) {
-//     throw new Error('Cloning projects with deploytarget configurations is not currently supported');
-//   }
+// check if the project has deploytarget configurations - not currently supported for cloning
+  const deployTargetConfigs = await query(sqlClientPool, deployTargetConfigSql.selectDeployTargetConfigsByProjectId(sourceProject.id));
+  if (deployTargetConfigs && deployTargetConfigs.length > 0) {
+    throw new Error('Cloning projects with deploytarget configurations is not currently supported');
+  }
 
   // clone the project schema and create new project from source project
   // remove fields from source that aren't required

--- a/services/api/src/resources/project/resolvers.ts
+++ b/services/api/src/resources/project/resolvers.ts
@@ -1232,16 +1232,16 @@ export const cloneProject: ResolverFn = async (
     }
 
 // check if environment exists + at least one successful deployment
-  const latestDeployment = await query(sqlClientPool, deploymentSql.selectLatestDeploymentForEnvironment(environmentData.id));
-  if (latestDeployment && latestDeployment[0]?.status !== 'complete') {
-    throw new Error('The source environment must have at least one successful deployment');
-  }
+//   const latestDeployment = await query(sqlClientPool, deploymentSql.selectLatestDeploymentForEnvironment(environmentData.id));
+//   if (latestDeployment && latestDeployment[0]?.status !== 'complete') {
+//     throw new Error('The source environment must have at least one successful deployment');
+//   }
 
-// check if the project has deploytarget configurations - not currently supported for cloning
-  const deployTargetConfigs = await query(sqlClientPool, deployTargetConfigSql.selectDeployTargetConfigsByProjectId(sourceProject.id));
-  if (deployTargetConfigs && deployTargetConfigs.length > 0) {
-    throw new Error('Cloning projects with deploytarget configurations is not currently supported');
-  }
+// // check if the project has deploytarget configurations - not currently supported for cloning
+//   const deployTargetConfigs = await query(sqlClientPool, deployTargetConfigSql.selectDeployTargetConfigsByProjectId(sourceProject.id));
+//   if (deployTargetConfigs && deployTargetConfigs.length > 0) {
+//     throw new Error('Cloning projects with deploytarget configurations is not currently supported');
+//   }
 
   // clone the project schema and create new project from source project
   // remove fields from source that aren't required
@@ -1682,7 +1682,7 @@ export const cancelProjectClone: ResolverFn = async (
   {
     input: {
       cloneId,
-      deleteResources = false,
+      cleanupClone = false,
     }
   },
   { sqlClientPool, hasPermission, userActivityLogger, models, adminScopes, keycloakGrant, legacyGrant }
@@ -1780,11 +1780,10 @@ export const cancelProjectClone: ResolverFn = async (
     pubSub.publish(EVENTS.PROJECTCLONE, updatedCloneRows[0]);
     pubSub.publish(EVENTS.ORGPROJECT, destProject);
   }
-  // delete any uploaded files
-  await deleteFilesForProjectClone(root, { input: { id: cloneId } }, { sqlClientPool, hasPermission, userActivityLogger, models, adminScopes, keycloakGrant, legacyGrant });
 
-  if (deleteResources) {
-    // delete cloned environment
+  if (cleanupClone) {
+    await deleteFilesForProjectClone(root, { input: { id: cloneId } }, { sqlClientPool, hasPermission, userActivityLogger, models, adminScopes, keycloakGrant, legacyGrant });
+
     if (destEnvRows?.length > 0) {
       const destEnv = destEnvRows[0];
 
@@ -1834,12 +1833,12 @@ export const cancelProjectClone: ResolverFn = async (
     } catch (err) {
       logger.error(`Could not delete default user for ${destProject.name}: ${err.message}`);
     }
-  }
 
   // delete clone task/deployment associations
-  await query(sqlClientPool, Sql.deleteProjectCloneTaskDeployments(cloneId));
+    await query(sqlClientPool, Sql.deleteProjectCloneTaskDeployments(cloneId));
   // delete the ProjectClone reference
-  await query(sqlClientPool, Sql.deleteProjectClone(cloneId));
+    await query(sqlClientPool, Sql.deleteProjectClone(cloneId));
+  }
 
   const auditLog: AuditLog = {
     resource: {
@@ -1850,16 +1849,17 @@ export const cancelProjectClone: ResolverFn = async (
     organizationId: sourceProject.organization
   };
 
-  userActivityLogger(`User cancelled a project clone for project '${destProject.name}'`, {
+  const actionType = cleanupClone ? 'cancelled and cleaned up' : 'cancelled';
+  userActivityLogger(`User ${actionType} a project clone for project '${destProject.name}'`, {
     project: '',
     event: 'api:cancelProjectClone',
     payload: {
-      data: destProject,
+      data: { ...destProject, cleanupClone },
       ...auditLog,
     }
   });
 
-  return 'success';
+  return updatedCloneRows.length > 0 ? updatedCloneRows[0] : null;
 };
 
 /*

--- a/services/api/src/typeDefs.js
+++ b/services/api/src/typeDefs.js
@@ -2901,7 +2901,7 @@ const typeDefs = gql`
 
   input CancelProjectCloneInput {
     cloneId: Int!
-    deleteResources: Boolean
+    cleanupClone: Boolean!
   }
 
   """
@@ -3376,7 +3376,7 @@ const typeDefs = gql`
     updateProjectClone(input: UpdateProjectCloneInput): ProjectClone
     executeCloneRestoreTask(input: ExecuteCloneRestoreTaskInput!): Task
     executeCloneDeployment(input: ExecuteCloneDeploymentInput!): String
-    cancelProjectClone(input: CancelProjectCloneInput!): String
+    cancelProjectClone(input: CancelProjectCloneInput!): ProjectClone
     copyProjectGroups(sourceProject: String!, destinationProject: String!): String
     copyProjectNotifications(sourceProject: String!, destinationProject: String!): String
     copyProjectMetadata(sourceProject: String!, destinationProject: String!): String


### PR DESCRIPTION
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Database Migrations

- [ ] If your PR contains a database migration, it **MUST** be the latest in date order alphabetically

# Description

Updates how `cancelProjectClone` optionally cleans up clones + resources on cancel. `cleanupClone` is `false` by default and leaves all resources, restrictions etc intact at the point the cancellation occurs. With cleanup enabled all resources are deleted. 

Required for https://github.com/uselagoon/lagoon-beta-ui/pull/174