### PR TITLE
docs: update SimpleSAMLphp instructions for 2.x

### DIFF
--- a/docs/ja/using-lagoon-advanced/simplesaml.md
+++ b/docs/ja/using-lagoon-advanced/simplesaml.md
@@ -14,7 +14,7 @@ composer req simplesamlphp/simplesamlphp
 
 ### SimpleSAMLphpの設定を変更する
 
-`vendor/simplesamlphp/simplesamlphp/config-templates`から`authsources.php`と`config.php`を`vendor`ディレクトリ外の`conf/simplesamlphp`のような場所にコピーします。また、`vendor/simplesamlphp/simplesamlphp/metadata-templates`から`saml20-idp-remote.php`も必要です。
+`vendor/simplesamlphp/simplesamlphp/config`から`authsources.php.dist`と`config.php.dist`を`vendor`ディレクトリ外の`conf/simplesamlphp`のような場所にコピーし、ファイル名から`.dist`の接尾辞を取り除きます。また、`vendor/simplesamlphp/simplesamlphp/metadata`から`saml20-idp-remote.php.dist`も必要です。
 
 `config.php`でLagoonに以下の値を設定します:
 
@@ -34,12 +34,20 @@ SimpleSAMLphpにアクセスするための基本URLパス:
     getenv('MARIADB_PORT'),
     getenv('MARIADB_DATABASE'),
   ]),
+  'store.sql.username'            => getenv('MARIADB_USERNAME'),
+  'store.sql.password'            => getenv('MARIADB_PASSWORD'),
+```
+
+SimpleSAMLphpはシークレットソルトをデフォルト値から変更することを必須としているため、これを設定します。`MARIADB_HOST`は環境ごとに一意なUUIDであるため、この値の元として便利です:
+
+```php title="config.php"
+  'secretsalt' => getenv('MARIADB_HOST'),
 ```
 
 他の設定はお好みで設定してください。
 
 * ログと証明書のパスを確認します
-* SimpleSAMLphpダッシュボードを保護します
+* `auth.adminpassword`をデフォルト値の`123`から変更して、SimpleSAMLphpダッシュボードを保護します。ここで使用するハッシュ値は`vendor/simplesamlphp/simplesamlphp/bin/pwgen.php`で生成できます
 * ロギングのレベルを設定します
 * `technicalcontact`と`timezone`を設定します
 
@@ -127,7 +135,7 @@ $metadata['https://YOUR_IDP_DOMAIN.TLD'] = [
 
 ```bash title="location_prepend_simplesamlphp.conf"
 location ^~ /simplesaml {
-    alias /app/vendor/simplesamlphp/simplesaml php/www;
+    alias /app/vendor/simplesamlphp/simplesamlphp/public;
 
     location ~ ^(?<prefix>/simplesaml)(?<phpfile>.+?\.php)(?<pathinfo>/.*)?$ {
         include          fastcgi_params;

--- a/docs/using-lagoon-advanced/simplesaml.md
+++ b/docs/using-lagoon-advanced/simplesaml.md
@@ -2,7 +2,7 @@
 
 ## SimpleSAMLphp
 
-This is an example of how to add SimpleSAMLphp to your project and then modify configuration to serve it via NGINX.
+This is an example of how to add SimpleSAMLphp to your project and then modify the configuration to serve it via NGINX.
 
 ### Requirements
 
@@ -14,9 +14,9 @@ composer req simplesamlphp/simplesamlphp
 
 ### Modify configuration for SimpleSAMLphp
 
-Copy `authsources.php` and `config.php` from `vendor/simplesamlphp/simplesamlphp/config-templates` to somewhere outside vendor directory, such as `conf/simplesamlphp`. You also need `saml20-idp-remote.php` from `vendor/simplesamlphp/simplesamlphp/metadata-templates`.
+Copy `authsources.php.dist` and `config.php.dist` from `vendor/simplesamlphp/simplesamlphp/config` to somewhere outside the vendor directory, such as `conf/simplesamlphp`, dropping the `.dist` suffix from the filenames. You also need `saml20-idp-remote.php.dist` from `vendor/simplesamlphp/simplesamlphp/metadata`.
 
-In `config.php` set following values for Lagoon:
+In `config.php` set the following values for Lagoon:
 
 Base URL path where SimpleSAMLphp is accessed:
 
@@ -24,26 +24,33 @@ Base URL path where SimpleSAMLphp is accessed:
   'baseurlpath' => 'https://YOUR_DOMAIN.TLD/simplesaml/',
 ```
 
-Store sessions to database:
+Store sessions to the database:
 
 ```php title="config.php"
   'store.type'                    => 'sql',
-
   'store.sql.dsn'                 => vsprintf('mysql:host=%s;port=%s;dbname=%s', [
     getenv('MARIADB_HOST'),
     getenv('MARIADB_PORT'),
     getenv('MARIADB_DATABASE'),
   ]),
+  'store.sql.username'            => getenv('MARIADB_USERNAME'),
+  'store.sql.password'            => getenv('MARIADB_PASSWORD'),
+```
+
+Set the secret salt, which SimpleSAMLphp requires you to change from its default value. `MARIADB_HOST` is a UUID that is unique to each environment, which makes it a convenient source for this value:
+
+```php title="config.php"
+  'secretsalt' => getenv('MARIADB_HOST'),
 ```
 
 Alter other settings to your liking:
 
 * Check the paths for logs and certs.
-* Secure SimpleSAMLphp dashboard.
-* Set up level of logging.
+* Secure the SimpleSAMLphp dashboard by changing `auth.adminpassword` from its default of `123`. Run `vendor/simplesamlphp/simplesamlphp/bin/pwgen.php` to generate a hashed value to use here.
+* Set up the level of logging.
 * Set `technicalcontact` and `timezone`.
 
-Add authsources \(IdPs\) to `authsources.php`, see example:
+Add authsources (IdPs) to `authsources.php`, see example:
 
 ```php title="authsources.php"
   'default-sp' => [
@@ -127,7 +134,7 @@ Create file  `lagoon/nginx/location_prepend_simplesamlphp.conf`:
 
 ```bash title="location_prepend_simplesamlphp.conf"
 location ^~ /simplesaml {
-    alias /app/vendor/simplesamlphp/simplesamlphp/www;
+    alias /app/vendor/simplesamlphp/simplesamlphp/public;
 
     location ~ ^(?<prefix>/simplesaml)(?<phpfile>.+?\.php)(?<pathinfo>/.*)?$ {
         include          fastcgi_params;
@@ -142,7 +149,7 @@ location ^~ /simplesaml {
 
 This will route `/simplesaml` URLs to SimpleSAMLphp in vendor.
 
-### Add additional NGINX conf to NGINX image
+### Add additional NGINX conf to the NGINX image
 
 Modify `nginx.dockerfile` and add `location_prepend_simplesamlphp.conf` to the image:
 


### PR DESCRIPTION
SimpleSAMLphp 2.0 reshuffled its layout and the docs still described 1.x, so the example config could not be followed end to end.

- NGINX alias points at public/ rather than www/, per the simplesamlphp_auth change record https://www.drupal.org/project/simplesamlphp_auth/issues/3340606
- Config and metadata templates now live in config/ and metadata/ as .dist files; config-templates/ and metadata-templates/ no longer exist
- Add store.sql.username and store.sql.password, without which the SQL session store cannot authenticate against MariaDB
- Set secretsalt, which SimpleSAMLphp requires to be changed from its default
- Name auth.adminpassword and bin/pwgen.php in the dashboard bullet

Also fixes a stray space that broke the alias path in the Japanese doc.

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog