### PR TITLE
fix: updating a retention policy always applies it to all projects

### DIFF
--- a/services/api/src/resources/retentionpolicy/resolvers.ts
+++ b/services/api/src/resources/retentionpolicy/resolvers.ts
@@ -137,10 +137,16 @@ const updateRetentionPolicy = async (sqlClientPool, hasPermission, userActivityL
 
   if (retpol.configuration != row.configuration) {
     // if a policy is updated, and the configuration is not the same as before the update
-    // then run postRetentionPolicyUpdateHook to make sure that the policy enforcer does
-    // any policy updates for any impacted projects
-    const policyEnabled = input.patch.enabled
-    await Helpers(sqlClientPool).postRetentionPolicyUpdateHook(retpol.type, retpol.id, null, !policyEnabled)
+    // then run the appropriate hook for each scope linked to the policy
+    const policyLinks = await query(sqlClientPool, Sql.selectRetentionPolicyLinksByPolicyID(retpol.id))
+    for (const policyLink of policyLinks) {
+      if (policyLink.scope == "global") {
+        const policyEnabled = input.patch.enabled
+        await Helpers(sqlClientPool).postRetentionPolicyUpdateHook(retpol.type, retpol.id, null, !policyEnabled)
+      } else {
+        await Helpers(sqlClientPool).postRetentionPolicyLinkHook(policyLink.id, policyLink.scope, retpol.type, retpol.id)
+      }
+    }
   }
 
   return { ...row, configuration: {type: row.type, ...JSON.parse(row.configuration)} };

--- a/services/api/src/resources/retentionpolicy/sql.ts
+++ b/services/api/src/resources/retentionpolicy/sql.ts
@@ -59,6 +59,10 @@ export const Sql = {
       .where(knex.raw('retention_policy_reference.scope = ?', scope))
       .andWhere(knex.raw('rp.id = ?', id))
       .toString(),
+  selectRetentionPolicyLinksByPolicyID: (id: number) =>
+    knex('retention_policy_reference')
+      .where('retention_policy', '=', id)
+      .toString(),
   selectScopeIDsByRetentionPolicyTypeExcludingPolicyID: (type: string, scope: string, policyId: number) =>
     knex('retention_policy as rp')
       .select(knex.raw('group_concat(rpr.id) as scope_ids'))


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Database Migrations

n/a

# Description

Updating a retention policy always calls `postRetentionPolicyUpdateHook` which treats the policy like a global one. This results in the policy being applied to all projects, regardless of it's links or overrides.

The fix is to first check if it is linked at all, and to use the correct post update hook for global vs org/project scoped links.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

n/a
