### PR TITLE
fix: attempting to interrupt program in api-db/keycloak-db kills bash

### DIFF
--- a/services/api-db/password-entrypoint.bash
+++ b/services/api-db/password-entrypoint.bash
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -eo pipefail
-
 if [ ${API_DB_PASSWORD+x} ]; then
     if [ "${LAGOON}" == "mysql" ]; then
         export MYSQL_PASSWORD=${API_DB_PASSWORD}

--- a/services/keycloak-db/password-entrypoint.bash
+++ b/services/keycloak-db/password-entrypoint.bash
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -eo pipefail
-
 if [ ${KEYCLOAK_DB_PASSWORD+x} ]; then
     if [ "${LAGOON}" == "mysql" ]; then
         export MYSQL_PASSWORD=${KEYCLOAK_DB_PASSWORD}


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Database Migrations

n/a

# Description

When bash is configured with `errexit`, it kills the session even when you are trying to quit a program which is very annoying.

1. Run `make api-development`
2. Start a bash session `dco -p lagoon exec api-db bash`
3. Run a command, eg `less /etc/mysql/my.cnf`
4. Press ctrl + c
5. The bash session is killed, not just `less`    

This happens because the [`set -eo pipefail`](https://github.com/uselagoon/lagoon/blob/8e67dadfe79c15d63d17b3b989cfa324fffc7847/services/api-db/password-entrypoint.bash#L3) in an [entrypoint](https://github.com/uselagoon/lagoon/blob/8e67dadfe79c15d63d17b3b989cfa324fffc7847/services/api-db/Dockerfile#L11) is [sourced](https://github.com/uselagoon/lagoon-images/blob/d1cfecb3747cbad6b4571f7a12df15405f340e9b/images/commons/.bashrc#L10) in `.bashrc` which sets `errexit` for the entire session.

Other entrypoints can `set -e` but they are executed instead of sourced, so they don't pollute the bash session.

<!--
# Changelog Entry
Lagoon is using GitHub's in-built automated release notes feature to create changelogs using PR titles

Please ensure that this PR has a concise and descriptive title - they can be edited after merging, but not after release.
-->

# Closing issues

n/a
